### PR TITLE
GP949: Use postcode.at extension also in rapid create form adress fields

### DIFF
--- a/CRM/Contract/Form/RapidCreate.php
+++ b/CRM/Contract/Form/RapidCreate.php
@@ -22,6 +22,12 @@ class CRM_Contract_Form_RapidCreate extends CRM_Core_Form{
     $this->add('text', 'street_address', 'Address');
     $this->add('text', 'postal_code', 'Postcode');
     $this->add('text', 'city', 'City');
+
+    $this->addChainSelect('state_province_id');
+
+    $country = array('' => ts('- select -')) + CRM_Core_PseudoConstant::country();
+    $this->add('select', 'country_id', ts('Country'), $country, TRUE, array('class' => 'crm-select2'));
+
     $this->addDate('birth_date', 'Date of Birth', true, array('formatType' => 'birth'));
 
     $this->addCheckbox('community_newsletter', 'Add to Community newsletter', ['' => true]);
@@ -162,6 +168,13 @@ class CRM_Contract_Form_RapidCreate extends CRM_Core_Form{
     $defaults['payment_frequency'] = '12'; // monthly
     $defaults['cycle_day'] = CRM_Contract_SepaLogic::nextCycleDay();
 
+    $config = CRM_Core_Config::singleton();
+    $countryDefault = $config->defaultContactCountry;
+
+    if ($countryDefault) {
+      $defaults['country_id'] = $countryDefault;
+    }
+
     parent::setDefaults($defaults);
   }
 
@@ -196,7 +209,9 @@ class CRM_Contract_Form_RapidCreate extends CRM_Core_Form{
         'street_address' => $submitted['street_address'],
         'city' => $submitted['city'],
         'postal_code' => $submitted['postal_code'],
-        'location_type_id' => 'home'
+        'state_province_id' => $submitted['state_province_id'],
+        'country_id' => $submitted['country_id'],
+        'location_type_id' => 'home',
       ]);
     }
 

--- a/CRM/Contract/Form/RapidCreate.php
+++ b/CRM/Contract/Form/RapidCreate.php
@@ -11,6 +11,7 @@ class CRM_Contract_Form_RapidCreate extends CRM_Core_Form{
 
   function buildQuickForm(){
     CRM_Core_Resources::singleton()->addScriptFile('de.systopia.contract', 'templates/CRM/Contract/Form/RapidCreate.js');
+    CRM_Core_Resources::singleton()->addScriptFile('de.systopia.contract', 'js/rapidcreate_address_autocomplete.js', 10, 'page-header');
     // ### Contact information ###
     $prefixes = array_column(civicrm_api3('OptionValue', 'get', ['option_group_id' => 'individual_prefix', 'is_active' => 1])['values'], 'label', 'value');
     $this->add('select', 'prefix_id', 'Prefix', $prefixes, true);

--- a/js/rapidcreate_address_autocomplete.js
+++ b/js/rapidcreate_address_autocomplete.js
@@ -19,15 +19,16 @@ function rapidcreate_addressfields() {
   fields['postcode'] = CRM.$('#postal_code');
   fields['city'] = CRM.$('#city');
   fields['street'] = CRM.$('#street_address');
+  fields['country'] = CRM.$('#country_id');
   return fields;
 }
 
 /*
  * Function to retrieve the postcode and fill the fields
  */
-function rapidcreate_setstateprovince(blockId, postcode) {
+function rapidcreate_setstateprovince(postcode) {
   //check if country is AT.
-  if ((cj('#address_' + blockId + '_country_id').val()) != 1014) {
+  if ((CRM.$('#country_id').val()) != 1014) {
     return;
   }
 
@@ -38,7 +39,7 @@ function rapidcreate_setstateprovince(blockId, postcode) {
         var id = data.id;
         var obj = data.values[id];
         var state = data.values[id][0].state;
-        cj('#address_' + blockId + '_state_province_id').select2('data', {
+        CRM.$('#state_province_id').select2('data', {
           id: id,
           text: state
         });
@@ -50,7 +51,7 @@ function rapidcreate_setstateprovince(blockId, postcode) {
 function rapidcreate_autofill(currentField) {
   var fields = rapidcreate_addressfields();
 
-  cj.ajax( {
+  CRM.$.ajax( {
     url: CRM.url('civicrm/ajax/postcodeat/autocomplete'),
     dataType: "json",
     data: {
@@ -76,17 +77,21 @@ function rapidcreate_init_addressBlock() {
 
   fields['postcode'].focusout(function(e) {
     rapidcreate_autofill(0);
-    //postcodeat_setstateprovince(blockId, postcode_field.val());
+    rapidcreate_setstateprovince(fields['postcode'].val());
   });
 
   fields['city'].focusout(function(e) {
     rapidcreate_autofill(1);
-    //rapidcreate_setstateprovince(blockId, postcode_field.val());
+    rapidcreate_setstateprovince(fields['postcode'].val());
   });
 
   fields['street'].focusout(function(e) {
     rapidcreate_autofill(2);
-    //rapidcreate_setstateprovince(blockId, postcode_field.val());
+    rapidcreate_setstateprovince(fields['postcode'].val());
+  });
+
+  fields['country'].change(function(e) {
+    autocomplete();
   });
 }
 
@@ -99,10 +104,10 @@ function autocomplete() {
   fields['street'].autocomplete();
   fields['city'].autocomplete();
 
-  //if ((cj('#address_' + blockId + '_country_id').val()) == 1014) {
+  if ((fields['country'].val()) == 1014) {
     fields['postcode'].autocomplete({
       source: function( request, response ) {
-        cj.ajax( {
+        CRM.$.ajax( {
           url: CRM.url('civicrm/ajax/postcodeat/autocomplete'),
           dataType: "json",
           data: {
@@ -124,12 +129,12 @@ function autocomplete() {
       minLength: 0
     })
       .focus(function() {
-        cj(this).autocomplete("search", "");
+        CRM.$(this).autocomplete("search", "");
       });
 
     fields['city'].autocomplete({
       source: function( request, response ) {
-        cj.ajax( {
+        CRM.$.ajax( {
           url: CRM.url('civicrm/ajax/postcodeat/autocomplete'),
           dataType: "json",
           data: {
@@ -151,12 +156,12 @@ function autocomplete() {
       minLength: 0
     })
       .focus(function() {
-        cj(this).autocomplete("search", "");
+        CRM.$(this).autocomplete("search", "");
       });
 
     fields['street'].autocomplete({
       source: function( request, response ) {
-        cj.ajax( {
+        CRM.$.ajax( {
           url: CRM.url('civicrm/ajax/postcodeat/autocomplete'),
           dataType: "json",
           data: {
@@ -185,13 +190,13 @@ function autocomplete() {
     fields['street'].autocomplete("enable");
     fields['city'].autocomplete("enable");
 
-  /*}
+  }
   else {
     // Disable autocomplete
     fields['postcode'].autocomplete("disable");
     fields['street'].autocomplete("disable");
     fields['city'].autocomplete("disable");
-  }*/
+  }
 }
 
 CRM.$(function($) {

--- a/js/rapidcreate_address_autocomplete.js
+++ b/js/rapidcreate_address_autocomplete.js
@@ -1,0 +1,200 @@
+/*-------------------------------------------------------+
+ | SYSTOPIA - Postcode Lookup for Austria                 |
+ | Copyright (C) 2017 SYSTOPIA                            |
+ | Author: M. Wire (mjw@mjwconsult.co.uk)                 |
+ |         B. Endres (endres@systopia.de)                 |
+ | http://www.systopia.de/                                |
+ +--------------------------------------------------------+
+ | This program is released as free software under the    |
+ | Affero GPL license. You can redistribute it and/or     |
+ | modify it under the terms of this license which you    |
+ | can read by viewing the included agpl.txt or online    |
+ | at www.gnu.org/licenses/agpl.html. Removal of this     |
+ | copyright header is strictly prohibited without        |
+ | written permission from the original author(s).        |
+ +--------------------------------------------------------*/
+
+function rapidcreate_addressfields() {
+  var fields = new Array();
+  fields['postcode'] = CRM.$('#postal_code');
+  fields['city'] = CRM.$('#city');
+  fields['street'] = CRM.$('#street_address');
+  return fields;
+}
+
+/*
+ * Function to retrieve the postcode and fill the fields
+ */
+function rapidcreate_setstateprovince(blockId, postcode) {
+  //check if country is AT.
+  if ((cj('#address_' + blockId + '_country_id').val()) != 1014) {
+    return;
+  }
+
+  var fields = rapidcreate_addressfields();
+  CRM.api3('PostcodeAT', 'getatstate', {'plznr': fields['postcode'].val(), 'ortnam': fields['city'].val(), 'stroffi': fields['street'].val()},
+    {success: function(data) {
+      if (data.is_error == 0 && data.count == 1) {
+        var id = data.id;
+        var obj = data.values[id];
+        var state = data.values[id][0].state;
+        cj('#address_' + blockId + '_state_province_id').select2('data', {
+          id: id,
+          text: state
+        });
+      }
+    }
+    });
+}
+
+function rapidcreate_autofill(currentField) {
+  var fields = rapidcreate_addressfields();
+
+  cj.ajax( {
+    url: CRM.url('civicrm/ajax/postcodeat/autocomplete'),
+    dataType: "json",
+    data: {
+      mode: 1,
+      plznr: fields['postcode'].val(),
+      ortnam: fields['city'].val(),
+      stroffi: fields['street'].val(),
+    },
+    success: function( data ) {
+      var plznr = data[0].plznr;
+      var ortnam = data[0].ortnam;
+      var stroffi = data[0].stroffi;
+
+      if (currentField != 0) fields['postcode'].val(plznr);
+      if (currentField != 1) fields['city'].val(ortnam);
+      if (currentField != 2) fields['street'].val(stroffi);
+    }
+  });
+}
+
+function rapidcreate_init_addressBlock() {
+  var fields = rapidcreate_addressfields();
+
+  fields['postcode'].focusout(function(e) {
+    rapidcreate_autofill(0);
+    //postcodeat_setstateprovince(blockId, postcode_field.val());
+  });
+
+  fields['city'].focusout(function(e) {
+    rapidcreate_autofill(1);
+    //rapidcreate_setstateprovince(blockId, postcode_field.val());
+  });
+
+  fields['street'].focusout(function(e) {
+    rapidcreate_autofill(2);
+    //rapidcreate_setstateprovince(blockId, postcode_field.val());
+  });
+}
+
+// Add autocomplete functions to postcode, street, city fields
+function autocomplete() {
+  var fields = rapidcreate_addressfields();
+
+  // Init autocomplete
+  fields['postcode'].autocomplete();
+  fields['street'].autocomplete();
+  fields['city'].autocomplete();
+
+  //if ((cj('#address_' + blockId + '_country_id').val()) == 1014) {
+    fields['postcode'].autocomplete({
+      source: function( request, response ) {
+        cj.ajax( {
+          url: CRM.url('civicrm/ajax/postcodeat/autocomplete'),
+          dataType: "json",
+          data: {
+            mode: 0,
+            term : request.term,
+            plznr: fields['postcode'].val(),
+            ortnam: fields['city'].val(),
+            stroffi: fields['street'].val(),
+            return: 'plznr'
+          },
+          success: function( data ) {
+            response( data );
+          }
+        });
+      },
+      width: 280,
+      selectFirst: true,
+      matchContains: true,
+      minLength: 0
+    })
+      .focus(function() {
+        cj(this).autocomplete("search", "");
+      });
+
+    fields['city'].autocomplete({
+      source: function( request, response ) {
+        cj.ajax( {
+          url: CRM.url('civicrm/ajax/postcodeat/autocomplete'),
+          dataType: "json",
+          data: {
+            mode: 0,
+            term : request.term,
+            plznr: fields['postcode'].val(),
+            ortnam: fields['city'].val(),
+            stroffi: fields['street'].val(),
+            return: 'ortnam'
+          },
+          success: function( data ) {
+            response( data );
+          }
+        });
+      },
+      width: 280,
+      selectFirst: true,
+      matchContains: true,
+      minLength: 0
+    })
+      .focus(function() {
+        cj(this).autocomplete("search", "");
+      });
+
+    fields['street'].autocomplete({
+      source: function( request, response ) {
+        cj.ajax( {
+          url: CRM.url('civicrm/ajax/postcodeat/autocomplete'),
+          dataType: "json",
+          data: {
+            mode: 0,
+            term : request.term,
+            plznr: fields['postcode'].val(),
+            ortnam: fields['city'].val(),
+            stroffi: fields['street'].val(),
+            return: 'stroffi'
+          },
+          success: function( data ) {
+            response( data );
+          }
+        });
+      },
+      width: 280,
+      selectFirst: true,
+      matchContains: true,
+      minLength: 0
+    })
+      .focus(function() {
+        CRM.$(this).autocomplete("search", "");
+      });
+
+    fields['postcode'].autocomplete("enable");
+    fields['street'].autocomplete("enable");
+    fields['city'].autocomplete("enable");
+
+  /*}
+  else {
+    // Disable autocomplete
+    fields['postcode'].autocomplete("disable");
+    fields['street'].autocomplete("disable");
+    fields['city'].autocomplete("disable");
+  }*/
+}
+
+CRM.$(function($) {
+  rapidcreate_init_addressBlock();
+  autocomplete();
+});

--- a/templates/CRM/Contract/Form/RapidCreate.tpl
+++ b/templates/CRM/Contract/Form/RapidCreate.tpl
@@ -61,6 +61,18 @@
   </div>
 
   <div class="crm-section">
+    <div class="label">{$form.state_province_id.label}</div>
+    <div class="content">{$form.state_province_id.html}</div>
+    <div class="clear"></div>
+  </div>
+
+  <div class="crm-section">
+    <div class="label">{$form.country_id.label}</div>
+    <div class="content">{$form.country_id.html}</div>
+    <div class="clear"></div>
+  </div>
+
+  <div class="crm-section">
     <div class="label">{$form.birth_date.label}</div>
     <div class="content">{include file="CRM/common/jcalendar.tpl" elementName=birth_date}</div>
     <div class="clear"></div>


### PR DESCRIPTION
* Add country/state fields.
* Add autocomplete for street, postcode, city, state (only if Country=Austria).
* PostcodeAT extension should be installed for this to work.