### PR TITLE
GP-1791: Use Currency from SEPA Creditor and Recurring Contribution

### DIFF
--- a/CRM/Contract/Form/Create.php
+++ b/CRM/Contract/Form/Create.php
@@ -170,7 +170,7 @@ class CRM_Contract_Form_Create extends CRM_Core_Form{
               'type'               => 'RCUR',
               'contact_id'         => $this->get('cid'),
               'amount'             => $amount,
-              'currency'           => 'EUR',
+              'currency'           => CRM_Contract_SepaLogic::getCreditor()->currency,
               'start_date'         => CRM_Utils_Date::processDate($submitted['start_date'], null, null, 'Y-m-d H:i:s'),
               'creation_date'      => date('YmdHis'), // NOW
               'date'               => CRM_Utils_Date::processDate($submitted['start_date'], null, null, 'Y-m-d H:i:s'),

--- a/CRM/Contract/Form/RapidCreate.php
+++ b/CRM/Contract/Form/RapidCreate.php
@@ -284,7 +284,7 @@ class CRM_Contract_Form_RapidCreate extends CRM_Core_Form{
       'type'               => 'RCUR',
       'contact_id'         => $contact['id'],
       'amount'             => $amount,
-      'currency'           => 'EUR',
+      'currency'           => CRM_Contract_SepaLogic::getCreditor()->currency,
       'start_date'         => CRM_Utils_Date::processDate($submitted['start_date'], null, null, 'Y-m-d H:i:s'),
       'creation_date'      => date('YmdHis'), // NOW
       'date'               => CRM_Utils_Date::processDate($submitted['start_date'], null, null, 'Y-m-d H:i:s'),

--- a/CRM/Contract/FormUtils.php
+++ b/CRM/Contract/FormUtils.php
@@ -62,6 +62,27 @@ class CRM_Contract_FormUtils
         }
     }
 
+    /**
+     * The currency for custom fields always defaults to the default currency.
+     * This converts the membership_payment.membership_annual field to string
+     * and manually formats it with the currency obtained from the recurring
+     * contribution.
+     *
+     * @throws \CiviCRM_API3_Exception
+     */
+    public function setPaymentAmountCurrency() {
+      $result = civicrm_api3('CustomField', 'getsingle', array('custom_group_id' => 'membership_payment', 'name' => 'membership_recurring_contribution'));
+      $details = $this->form->get_template_vars('viewCustomData');
+      $customGroupTableId = key($details[$result['custom_group_id']]);
+      $recContributionId = $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'];
+      $recContribution = civicrm_api3('ContributionRecur', 'getsingle', array('id' => $recContributionId));
+      $customGroupTableId = key($details[$result['custom_group_id']]);
+      $result = civicrm_api3('CustomField', 'getsingle', array('custom_group_id' => 'membership_payment', 'name' => 'membership_annual'));
+      $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'] = CRM_Utils_Money::format($details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'], $recContribution['currency']);
+      $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_data_type'] = 'String';
+      $this->form->assign('viewCustomData', $details);
+    }
+
     public function showMembershipTypeLabel()
     {
         $result = civicrm_api3('CustomField', 'getsingle', array('custom_group_id' => 'contract_updates', 'name' => 'ch_membership_type'));

--- a/CRM/Contract/RecurringContribution.php
+++ b/CRM/Contract/RecurringContribution.php
@@ -187,8 +187,8 @@ class CRM_Contract_RecurringContribution {
         Creditor account: {$result['fields']['org_iban']}<br />
         Payment method: {$result['fields']['payment_instrument']}<br />
         Frequency: {$result['fields']['frequency']}<br />
-        Annual amount: {$result['fields']['annual_amount']}&nbsp;EUR<br />
-        Installment amount: {$result['fields']['amount']}&nbsp;EUR<br />
+        Annual amount: {$result['fields']['annual_amount']}&nbsp;{$cr['currency']}<br />
+        Installment amount: {$result['fields']['amount']}&nbsp;{$cr['currency']}<br />
         Next debit: {$result['fields']['next_debit']}
       ";
 
@@ -198,8 +198,8 @@ class CRM_Contract_RecurringContribution {
         Debitor name: {$result['fields']['display_name']}<br />
         Payment method: {$result['fields']['payment_instrument']}<br />
         Frequency: {$result['fields']['frequency']}<br />
-        Annual amount: {$result['fields']['annual_amount']}&nbsp;EUR<br />
-        Installment amount: {$result['fields']['amount']}&nbsp;EUR<br />
+        Annual amount: {$result['fields']['annual_amount']}&nbsp;{$cr['currency']}<br />
+        Installment amount: {$result['fields']['amount']}&nbsp;{$cr['currency']}<br />
       ";
       $result['label'] = "{$result['fields']['payment_instrument']}, {$result['fields']['amount']} {$result['fields']['frequency']}";
     }

--- a/CRM/Contract/SepaLogic.php
+++ b/CRM/Contract/SepaLogic.php
@@ -157,7 +157,7 @@ class CRM_Contract_SepaLogic {
         'type'               => 'RCUR',
         'contact_id'         => $current_state['contact_id'],
         'amount'             => $amount,
-        'currency'           => 'EUR',
+        'currency'           => self::getCreditor()->currency,
         'start_date'         => self::getMandateUpdateStartDate($current_state, $current_state, $desired_state, $activity),
         'creation_date'      => date('YmdHis'), // NOW
         'date'               => date('YmdHis', strtotime($activity['activity_date_time'])),

--- a/CRM/Contract/SepaLogic.php
+++ b/CRM/Contract/SepaLogic.php
@@ -464,7 +464,8 @@ class CRM_Contract_SepaLogic {
    * @return int next valid cycle day
    */
   public static function nextCycleDay() {
-    $buffer_days = 2; // TODO: more?
+    $creditor = CRM_Sepa_Logic_Settings::defaultCreditor();
+    $buffer_days = (int) CRM_Sepa_Logic_Settings::getSetting("pp_buffer_days") + (int) CRM_Sepa_Logic_Settings::getSetting("batching.FRST.notice", $creditor->id);
     $cycle_days = self::getCycleDays();
 
     $safety_counter = 32;

--- a/contract.php
+++ b/contract.php
@@ -140,6 +140,7 @@ function contract_civicrm_buildForm($formName, &$form) {
       $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $form);
 
       $formUtils = new CRM_Contract_FormUtils($form, 'Membership');
+      $formUtils->setPaymentAmountCurrency();
       $formUtils->replaceIdWithLabel('membership_payment.membership_recurring_contribution', 'ContributionRecur');
       $formUtils->replaceIdWithLabel('membership_payment.payment_instrument', 'PaymentInstrument');
       $formUtils->replaceIdWithLabel('membership_payment.to_ba', 'BankAccountReference');

--- a/templates/CRM/Contract/Form/Create.tpl
+++ b/templates/CRM/Contract/Form/Create.tpl
@@ -49,7 +49,7 @@
   </div>
   <div class="crm-section payment-create">
     <div class="label">{$form.payment_amount.label}</div>
-    <div class="content">{$form.payment_amount.html}&nbsp;EUR</div>
+    <div class="content">{$form.payment_amount.html}&nbsp;<span id="payment_amount_currency"></span></div>
     <div class="clear"></div>
   </div>
   <div class="crm-section payment-create">
@@ -186,10 +186,12 @@ function updatePaymentSummaryText() {
       "Creditor account: " + creditor.iban + "<br/>" +
       "Payment method: SEPA Direct Debit<br/>" +
       "Frequency: " + freqency_label + "<br/>" +
-      "Annual amount: " + annual + " EUR<br/>" +
-      "Installment amount: " + installment.toFixed(2) + " EUR<br/>" +
+      "Annual amount: " + annual + " " + creditor.currency + "<br/>" +
+      "Installment amount: " + installment.toFixed(2) + " " + creditor.currency + "<br/>" +
       "Next debit: " + first_collection + "<br/>"
       );
+
+    cj('#payment_amount_currency').text(creditor.currency);
   }
 }
 

--- a/templates/CRM/Contract/Form/Modify.tpl
+++ b/templates/CRM/Contract/Form/Modify.tpl
@@ -56,7 +56,7 @@
     </div>
     <div class="crm-section payment-modify">
       <div class="label">{$form.payment_amount.label}</div>
-      <div class="content">{$form.payment_amount.html}&nbsp;EUR</div>
+      <div class="content">{$form.payment_amount.html}&nbsp;<span id="payment_amount_currency"></span></div>
       <div class="clear"></div>
     </div>
     <div class="crm-section payment-modify">
@@ -215,10 +215,12 @@ function updatePaymentSummaryText() {
       "Creditor account: " + creditor.iban + "<br/>" +
       "Payment method: SEPA Direct Debit<br/>" +
       "Frequency: " + freqency_label + "<br/>" +
-      "Annual amount: " + annual + " EUR<br/>" +
-      "Installment amount: " + installment.toFixed(2) + " EUR<br/>" +
+      "Annual amount: " + annual + " " + creditor.currency + "<br/>" +
+      "Installment amount: " + installment.toFixed(2) + " " + creditor.currency + "<br/>" +
       "Next debit: " + next_collection + "<br/>"
       );
+
+    cj('#payment_amount_currency').text(creditor.currency);
   }
 }
 

--- a/templates/CRM/Contract/Form/RapidCreate.tpl
+++ b/templates/CRM/Contract/Form/RapidCreate.tpl
@@ -108,7 +108,7 @@
   </div>
   <div class="crm-section payment-create">
     <div class="label">{$form.payment_amount.label}</div>
-    <div class="content">{$form.payment_amount.html}&nbsp;EUR</div>
+    <div class="content">{$form.payment_amount.html}&nbsp;<span id="payment_amount_currency"></span></div>
     <div class="clear"></div>
   </div>
   <div class="crm-section payment-create">
@@ -277,10 +277,12 @@ function updatePaymentSummaryText() {
     "Creditor account: " + creditor.iban + "<br/>" +
     "Payment method: SEPA Direct Debit<br/>" +
     "Frequency: " + freqency_label + "<br/>" +
-    "Annual amount: " + annual + " EUR<br/>" +
-    "Installment amount: " + installment.toFixed(2) + " EUR<br/>" +
+    "Annual amount: " + annual + " " + creditor.currency + "<br/>" +
+    "Installment amount: " + installment.toFixed(2) + " " + creditor.currency + "<br/>" +
     "Next debit: " + first_collection + "<br/>"
     );
+
+  cj('#payment_amount_currency').text(creditor.currency);
 }
 
 // call once for the UI to adjust


### PR DESCRIPTION
Instead of using a hardcoded currency value, use the currency associated with the creditor or recurring contribution, depending on the view.

Fixes #17