### PR TITLE
GP-1819: Fail if contract ID is empty in conflict check

### DIFF
--- a/CRM/Contract/Handler/ModificationConflicts.php
+++ b/CRM/Contract/Handler/ModificationConflicts.php
@@ -16,6 +16,9 @@ class CRM_Contract_Handler_ModificationConflicts{
   }
 
   function checkForConflicts($contractId){
+    if (empty($contractId)) {
+      throw new Exception('Missing contract ID, cannot check for conflicts');
+    }
 
     $this->contractId = $contractId;
     // Black and white listing happens as follows: an array of scheduled


### PR DESCRIPTION
This throws an exception if a conflict check is initiated with an empty contract ID. Without this check, the contract extension will set 10,000 unrelated activities with an empty source_record_id to "Needs Review".