### PR TITLE
GP-1839: Use campaign from previous recurring contribution

### DIFF
--- a/CRM/Contract/SepaLogic.php
+++ b/CRM/Contract/SepaLogic.php
@@ -89,14 +89,21 @@ class CRM_Contract_SepaLogic {
                         /* fallback: membership */ CRM_Utils_Array::value('membership_payment.membership_annual', $current_state));
       $frequency     = (int) CRM_Utils_Array::value('contract_updates.ch_frequency',
                         /* fallback: membership */ $desired_state, CRM_Utils_Array::value('membership_payment.membership_frequency', $current_state));
-      $campaign_id   = CRM_Utils_Array::value('campaign_id', $activity,
-                        /* fallback: membership */ CRM_Utils_Array::value('campaign_id', $current_state));
+
+      $recurring_contribution = null;
+      $recurring_contribution_id = (int) CRM_Utils_Array::value('membership_payment.membership_recurring_contribution', $current_state);
+      if ($recurring_contribution_id) {
+        $recurring_contribution = civicrm_api3('ContributionRecur', 'getsingle', ['id' => $recurring_contribution_id]);
+      }
+
+      $campaign_id = CRM_Utils_Array::value('campaign_id', $activity,
+        /* fallback: r. contrib. */ CRM_Utils_Array::value('campaign_id', $recurring_contribution));
+
 
       // fallback 2: take (still) missing from connected recurring contribution
       if (empty($cycle_day) || empty($frequency) || empty($annual_amount) || empty($from_ba)) {
-        $recurring_contribution_id = (int) CRM_Utils_Array::value('membership_payment.membership_recurring_contribution', $current_state);
-        if ($recurring_contribution_id) {
-          $recurring_contribution = civicrm_api3('ContributionRecur', 'getsingle', array('id' => $recurring_contribution_id));
+
+        if (!is_null($recurring_contribution)) {
           if (empty($cycle_day)) {
             $cycle_day = $recurring_contribution['cycle_day'];
           }


### PR DESCRIPTION
When a new mandate and recurring contribution is created, and if the activity campaign is empty, use the campaign of the previous recurring contribution instead of the membership campaign.