### PR TITLE
GP-1916: Add name for contract download script

### DIFF
--- a/CRM/Contract/FormUtils.php
+++ b/CRM/Contract/FormUtils.php
@@ -154,6 +154,7 @@ class CRM_Contract_FormUtils
           $script = str_replace('CONTRACT_FILE_DOWNLOAD', $url, $script);
           CRM_Core_Region::instance('page-footer')->add(array(
             'script' => $script,
+            'name'   => 'contract-download@de.systopia.contract',
           ));
         }
       }


### PR DESCRIPTION
This allows for easier customization of the download link in other extensions. See https://github.com/greenpeace-cee/at.greenpeace.uimods/commit/cc7b0de55cf9f17fb97d859684e88b0bf4ede231 for an example use-case.