### PR TITLE
GP-1790: Make start_date deferral for paid periods optional

### DIFF
--- a/CRM/Contract/Handler/Contract.php
+++ b/CRM/Contract/Handler/Contract.php
@@ -405,6 +405,7 @@ class CRM_Contract_Handler_Contract{
     $abbrevations['membership_payment.from_ba']='member iban';
     $abbrevations['membership_payment.cycle_day']='cycle day';
     $abbrevations['membership_payment.payment_instrument']='payment method';
+    $abbrevations['membership_payment.defer_payment_start'] = 'defer';
 
     $changesText = [];
 
@@ -458,6 +459,7 @@ class CRM_Contract_Handler_Contract{
       'membership_payment.to_ba',
       'membership_payment.cycle_day',
       'membership_payment.payment_instrument',
+      'membership_payment.defer_payment_start',
     ];
   }
 

--- a/CRM/Contract/Utils.php
+++ b/CRM/Contract/Utils.php
@@ -32,6 +32,7 @@ class CRM_Contract_Utils{
     'membership_payment.from_ba'                           => 'contract_updates.ch_from_ba',
     'membership_payment.to_ba'                             => 'contract_updates.ch_to_ba',
     'membership_payment.cycle_day'                         => 'contract_updates.ch_cycle_day',
+    'membership_payment.defer_payment_start'               => 'contract_updates.ch_defer_payment_start',
     'membership_cancellation.membership_cancel_reason'     => 'contract_cancellation.contact_history_cancel_reason',
 ];
 

--- a/api/v3/Contract.php
+++ b/api/v3/Contract.php
@@ -158,6 +158,7 @@ function civicrm_api3_Contract_modify($params){
     'membership_payment.cycle_day',
     'membership_payment.to_ba',
     'membership_payment.from_ba',
+    'membership_payment.defer_payment_start',
   ];
 
   foreach($expectedCustomFields as $expectedCustomField){
@@ -185,6 +186,7 @@ function civicrm_api3_Contract_modify($params){
         'membership_payment.cycle_day',
         'membership_payment.to_ba',
         'membership_payment.from_ba',
+        'membership_payment.defer_payment_start',
       ];
       foreach($updateFields as $updateField){
         if(isset($params[$updateField])){

--- a/resources/custom_group_contract_updates.json
+++ b/resources/custom_group_contract_updates.json
@@ -157,6 +157,23 @@
       "is_active": "1",
       "is_view": "1",
       "in_selector": "1"
+    },
+    {
+      "_lookup": ["column_name", "custom_group_id"],
+      "_translate": ["label"],
+      "weight": "10",
+      "name": "ch_defer_payment_start",
+      "column_name": "ch_defer_payment_start",
+      "label": "Defer Payment Start",
+      "data_type": "Boolean",
+      "html_type": "Radio",
+      "default_value": "1",
+      "is_required": "0",
+      "is_searchable": "1",
+      "is_search_range": "1",
+      "is_active": "1",
+      "is_view": "1",
+      "in_selector": "1"
     }
   ]
 }

--- a/resources/custom_group_membership_payment.json
+++ b/resources/custom_group_membership_payment.json
@@ -118,6 +118,22 @@
       "is_active": "1",
       "is_view": "0",
       "in_selector": "1"
+    },
+    {
+      "_lookup": ["column_name", "custom_group_id"],
+      "_translate": ["label"],
+      "weight": "8",
+      "name": "defer_payment_start",
+      "column_name": "defer_payment_start",
+      "label": "Defer Payment Start",
+      "data_type": "Boolean",
+      "html_type": "Radio",
+      "default_value": "1",
+      "is_required": "0",
+      "is_searchable": "1",
+      "is_active": "1",
+      "is_view": "0",
+      "in_selector": "1"
     }
   ]
 }


### PR DESCRIPTION
This adds a `defer_payment_start` field to `membership_payment`. If the field is set to `1` (default), new mandates created for existing memberships will respect already-paid membership periods and use a start date after the paid period. This was the previous behaviour.

If the value is set to `0`, contract modifications will not respect paid periods and use the current date for the mandate's start date.