### PR TITLE
Show correct currency on contract review page

### DIFF
--- a/CRM/Contract/Page/Review.php
+++ b/CRM/Contract/Page/Review.php
@@ -14,6 +14,16 @@ class CRM_Contract_Page_Review extends CRM_Core_Page {
       Throw new Exception('Missing a valid contract ID');
     }
 
+    // get contract currency from currently active recurring contribution
+    // TODO: make currency changeable/store it with the contract update
+    $membership = civicrm_api3('Membership', 'getsingle', [
+      'id' => CRM_Utils_Request::retrieve('id', 'Positive')
+    ]);
+    $this->assign('currency', civicrm_api3('ContributionRecur', 'getvalue', [
+      'id' => $membership[CRM_Contract_Utils::getCustomFieldId('membership_payment.membership_recurring_contribution')],
+      'return' => 'currency',
+    ]));
+
     // Set activity params
     $activityParams = [
       'source_record_id' => $id,

--- a/templates/CRM/Contract/Page/Review.tpl
+++ b/templates/CRM/Contract/Page/Review.tpl
@@ -35,7 +35,7 @@
       <td>{$a.id} {$activityTypes[$a.activity_type_id]}</td>
       <td>{$a.activity_date_time|crmDate}</td>
       <td><a href="{crmURL p='civicrm/contact/view/contributionrecur' q="reset=1&id=`$a.contract_updates_ch_recurring_contribution`&cid=`$a.recurring_contribution_contact_id`"}" class="crm-popup">{$paymentInstruments[$a.payment_instrument_id]}</a></td>
-      <td>{if $a.contract_updates_ch_annual || $a.contract_updates_ch_amount}{$a.contract_updates_ch_annual|crmMoney} ({$a.contract_updates_ch_amount|crmMoney}){/if}</td>
+      <td>{if $a.contract_updates_ch_annual || $a.contract_updates_ch_amount}{$a.contract_updates_ch_annual|crmMoney:$currency} ({$a.contract_updates_ch_amount|crmMoney:$currency}){/if}</td>
 
       <td>{$paymentFrequencies[$a.contract_updates_ch_frequency]}</td>
       <td>{$a.contract_updates_ch_cycle_day}</td>


### PR DESCRIPTION
Instead of always showing the default currency, this fetches the currency from the currently active recurring contribution.