### PR TITLE
Improve compatibility with CiviCRM 4.7+

### DIFF
--- a/CRM/Contract/Form/Create.php
+++ b/CRM/Contract/Form/Create.php
@@ -91,7 +91,11 @@ class CRM_Contract_Form_Create extends CRM_Core_Form{
     $this->add('select', 'membership_channel', ts('Membership channel'), array('' => '- none -') + $membershipChannelOptions, false, array('class' => 'crm-select2'));
 
     // Notes
-    $this->addWysiwyg('activity_details', ts('Notes'), []);
+    if (version_compare(CRM_Utils_System::version(), '4.7', '<')) {
+      $this->addWysiwyg('activity_details', ts('Notes'), []);
+    } else {
+      $this->add('wysiwyg', 'activity_details', ts('Notes'));
+    }
 
 
     $this->addButtons([

--- a/CRM/Contract/Form/Modify.php
+++ b/CRM/Contract/Form/Modify.php
@@ -92,7 +92,11 @@ class CRM_Contract_Form_Modify extends CRM_Core_Form{
     $this->add('select', 'activity_medium', ts('Source media'), array('' => '- none -') + $mediumOptions, false, array('class' => 'crm-select2'));
 
     // Add a note field
-    $this->addWysiwyg('activity_details', ts('Notes'), []);
+    if (version_compare(CRM_Utils_System::version(), '4.7', '<')) {
+      $this->addWysiwyg('activity_details', ts('Notes'), []);
+    } else {
+      $this->add('wysiwyg', 'activity_details', ts('Notes'));
+    }
 
     // Then add fields that are dependent on the action
     if(in_array($this->modificationActivity->getAction(), array('update', 'revive'))){

--- a/CRM/Contract/Form/RapidCreate/AT.php
+++ b/CRM/Contract/Form/RapidCreate/AT.php
@@ -120,7 +120,11 @@ class CRM_Contract_Form_RapidCreate_AT extends CRM_Core_Form{
     $this->add('select', 'membership_channel', ts('Membership channel'), array('' => '- none -') + $membershipChannelOptions, true, array('class' => 'crm-select2'));
 
     // Notes
-    $this->addWysiwyg('activity_details', ts('Notes'), ['class' => 'huge'], TRUE);
+    if (version_compare(CRM_Utils_System::version(), '4.7', '<')) {
+      $this->addWysiwyg('activity_details', ts('Notes'), ['class' => 'huge'], TRUE);
+    } else {
+      $this->add('wysiwyg', 'activity_details', ts('Notes'));
+    }
 
 
     $this->addButtons([

--- a/CRM/Contract/Form/RapidCreate/PL.php
+++ b/CRM/Contract/Form/RapidCreate/PL.php
@@ -113,7 +113,11 @@ class CRM_Contract_Form_RapidCreate_PL extends CRM_Core_Form {
     };
     $this->add('select', 'membership_channel', ts('Membership channel'), ['' => '- none -'] + $membershipChannelOptions, TRUE, ['class' => 'crm-select2']);
 
-    $this->addWysiwyg('activity_details', ts('Notes'), ['class' => 'huge'], TRUE);
+    if (version_compare(CRM_Utils_System::version(), '4.7', '<')) {
+      $this->addWysiwyg('activity_details', ts('Notes'), ['class' => 'huge'], TRUE);
+    } else {
+      $this->add('wysiwyg', 'activity_details', ts('Notes'));
+    }
 
 
     $this->addButtons([

--- a/CRM/Contract/FormUtils.php
+++ b/CRM/Contract/FormUtils.php
@@ -42,7 +42,7 @@ class CRM_Contract_FormUtils
         // this custom data is stored in
         if (isset($details[$result['custom_group_id']])) {
           $customGroupTableId = key($details[$result['custom_group_id']]);
-          if (isset($details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'])) {
+          if (!empty($details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'])) {
             $entityId = $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'];
             if($entity == 'ContributionRecur'){
               try {

--- a/CRM/Contract/Page/Review.php
+++ b/CRM/Contract/Page/Review.php
@@ -133,10 +133,10 @@ class CRM_Contract_Page_Review extends CRM_Core_Page {
 
     $this->assign('membershipTypes', $membershipTypes);
 
-
-
-
-    CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'packages/ckeditor/ckeditor.js');
+    // since Civi 4.7, wysiwyg/ckeditor is a default core resource
+    if (version_compare(CRM_Utils_System::version(), '4.7', '<')) {
+      CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'packages/ckeditor/ckeditor.js');
+    }
     foreach(civicrm_api3('CustomField', 'get', [ 'custom_group_id' => ['IN' => ['contract_cancellation', 'contract_updates']]])['values'] as $customField){
       $activityParams['return'][]='custom_'.$customField['id'];
     }

--- a/contract.php
+++ b/contract.php
@@ -259,7 +259,7 @@ function contract_civicrm_links( $op, $objectName, $objectId, &$links, &$mask, &
   if ($objectName == 'Membership') {
     // alter membership link
     $alter = new CRM_Contract_AlterMembershipLinks($objectId, $links, $mask, $values);
-    $alter->removeActions(array(CRM_Core_Action::RENEW, CRM_Core_Action::DELETE, CRM_Core_Action::UPDATE));
+    $alter->removeActions(array(CRM_Core_Action::RENEW, CRM_Core_Action::FOLLOWUP, CRM_Core_Action::DELETE, CRM_Core_Action::UPDATE));
     $alter->addHistoryActions();
 
   } elseif ($op=='contribution.selector.row') {

--- a/css/contract.css
+++ b/css/contract.css
@@ -6,3 +6,10 @@ table.dataTable.display tbody tr.needs-review,
 table.dataTable.display tbody tr.needs-review:hover {
     background-color: rgb(255,220,220);
 }
+
+/* exclude review rows from shoreditch overflow handling  */
+.page-civicrm-contact #memberships table tr.crm-membership-review table td:not(:last-child) {
+    max-width: unset;
+    overflow: unset;
+    text-overflow: unset;
+}


### PR DESCRIPTION
- Remove use of `addWysiwyg()` when running under 4.7+
- Remove resource reference to `ckeditor.js` when running under 4.7+
- Hide "Renew-Credit Card" membership action
- Exclude contract review rows from shoreditch overflow handling
- Don't load contract custom field label when value is empty