### PR TITLE
GP-2027: Apply formatMoney before doing any math

### DIFF
--- a/CRM/Contract/Form/RapidCreate/AT.php
+++ b/CRM/Contract/Form/RapidCreate/AT.php
@@ -150,7 +150,7 @@ class CRM_Contract_Form_RapidCreate_AT extends CRM_Core_Form{
       HTML_QuickForm::setElementError ( 'payment_amount', 'Please specify an amount when specifying a frequency');
     }
 
-    $amount = CRM_Contract_SepaLogic::formatMoney($submitted['payment_amount'] / $submitted['payment_frequency']);
+    $amount = CRM_Contract_SepaLogic::formatMoney(CRM_Contract_SepaLogic::formatMoney($submitted['payment_amount']) / $submitted['payment_frequency']);
     if ($amount < 0.01) {
       HTML_QuickForm::setElementError ( 'payment_amount', 'Annual amount too small.');
     }

--- a/CRM/Contract/Form/RapidCreate/PL.php
+++ b/CRM/Contract/Form/RapidCreate/PL.php
@@ -143,7 +143,7 @@ class CRM_Contract_Form_RapidCreate_PL extends CRM_Core_Form {
       HTML_QuickForm::setElementError('payment_amount', 'Please specify an amount when specifying a frequency');
     }
 
-    $amount = CRM_Contract_SepaLogic::formatMoney($submitted['payment_amount'] / $submitted['payment_frequency']);
+    $amount = CRM_Contract_SepaLogic::formatMoney(CRM_Contract_SepaLogic::formatMoney($submitted['payment_amount']) / $submitted['payment_frequency']);
     if ($amount < 0.01) {
       HTML_QuickForm::setElementError('payment_amount', 'Annual amount too small.');
     }

--- a/CRM/Contract/Handler/Contract.php
+++ b/CRM/Contract/Handler/Contract.php
@@ -566,7 +566,7 @@ class CRM_Contract_Handler_Contract{
       'month' => 12,
       'year' => 1
     );
-    return CRM_Contract_SepaLogic::formatMoney($contributionRecur['amount'] * $frequencyUnitTranslate[$contributionRecur['frequency_unit']] / $contributionRecur['frequency_interval']);
+    return CRM_Contract_SepaLogic::formatMoney(CRM_Contract_SepaLogic::formatMoney($contributionRecur['amount']) * $frequencyUnitTranslate[$contributionRecur['frequency_unit']] / $contributionRecur['frequency_interval']);
   }
 
   /**

--- a/CRM/Contract/SepaLogic.php
+++ b/CRM/Contract/SepaLogic.php
@@ -117,7 +117,7 @@ class CRM_Contract_SepaLogic {
             }
           }
           if (empty($annual_amount)) {
-            $annual_amount = self::formatMoney($recurring_contribution['amount'] * $frequency);
+            $annual_amount = self::formatMoney(self::formatMoney($recurring_contribution['amount']) * $frequency);
           }
           if (empty($from_ba)) {
             $mandate = self::getMandateForRecurringContributionID($recurring_contribution_id);
@@ -137,7 +137,7 @@ class CRM_Contract_SepaLogic {
 
       // calculate amount
       $frequency_interval = 12 / $frequency;
-      $amount = self::formatMoney($annual_amount / $frequency);
+      $amount = self::formatMoney(self::formatMoney($annual_amount) / $frequency);
       if ($amount < 0.01) {
         throw new Exception("Installment amount too small");
       }


### PR DESCRIPTION
Amounts of >= 1000 are returned using thousands separator in some places. This causes issues when attempting to do math with these values, potentially leading to massive changes in annual amount e.g. when resuming pauses.