### PR TITLE
GP-2075: Add logging schema fix to upgrader

### DIFF
--- a/CRM/Contract/Upgrader.php
+++ b/CRM/Contract/Upgrader.php
@@ -46,4 +46,11 @@ class CRM_Contract_Upgrader extends CRM_Contract_Upgrader_Base {
     return TRUE;
   }
 
+  public function upgrade_1390() {
+    $this->ctx->log->info('Applying update 1390');
+    $logging = new CRM_Logging_Schema();
+    $logging->fixSchemaDifferences();
+    return TRUE;
+  }
+
 }


### PR DESCRIPTION
Update 1370 included a schema change, but did not call `fixSchemaDifferences()`.