### PR TITLE
Fix reference to $this in static method

### DIFF
--- a/CRM/Contract/ModificationActivity.php
+++ b/CRM/Contract/ModificationActivity.php
@@ -60,7 +60,7 @@ abstract class CRM_Contract_ModificationActivity{
   static function findByStatusChange($startStatus, $endStatus){
     if ($startStatus == $endStatus) {
       // introducing NoStatuChange class, see GP-1207
-      return new CRM_Contract_ModificationActivity_NoStatusChange($this->startStatus);
+      return new CRM_Contract_ModificationActivity_NoStatusChange($startStatus);
     }
 
     foreach (self::$modificationActivityClasses as $class) {


### PR DESCRIPTION
`CRM_Contract_ModificationActivity::findByStatusChange` references `$this->startStatus` instead of `$startStatus`. That causes a warning on PHP 7.