### PR TITLE
Add CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,223 @@
+version: 2.1
+commands:
+  install_civicrm:
+    description: "Install CiviCRM"
+    parameters:
+      build_name:
+        type: string
+        default: master
+      type:
+        type: string
+        default: drupal-clean
+      version:
+        type: string
+        default: master
+      url:
+        type: string
+        default: http://localhost:8080
+    steps:
+      - run: |
+          civiver=<< parameters.version >>
+          if [[ "$civiver" == "stable" ]]; then
+            civiver=$(curl -s 'https://latest.civicrm.org/stable.php')
+          fi
+          su - buildkit -c "/buildkit/bin/civibuild create << parameters.build_name >> --civi-ver $civiver --type << parameters.type >> --url << parameters.url >>"
+  install_dependencies:
+    description: "Install Dependencies"
+    parameters:
+      build_name:
+        type: string
+        default: master
+    steps:
+      - run: |
+          EXT_DIR=/buildkit/build/<< parameters.build_name >>/web/sites/default/files/civicrm/ext
+          cd $EXT_DIR
+          git clone https://github.com/Project60/org.project60.sepa.git
+          git clone https://github.com/Project60/org.project60.banking.git banking-src
+          mv banking-src/extension org.project60.banking
+          rm -rf banking-src
+          chown buildkit:buildkit org.project60.sepa org.project60.banking -R
+          su - buildkit -c "cd /buildkit/build/<< parameters.build_name >>/web && cv en org.project60.sepa org.project60.banking"
+  install_extension:
+    description: "Install Extension"
+    parameters:
+      build_name:
+        type: string
+        default: master
+    steps:
+      - run: |
+          EXT_DIR=/buildkit/build/<< parameters.build_name >>/web/sites/default/files/civicrm/ext/$CIRCLE_PROJECT_REPONAME
+          cp /root/project $EXT_DIR -r
+          chown buildkit:buildkit $EXT_DIR -R
+          cd $EXT_DIR
+          su - buildkit -c "cd /buildkit/build/<< parameters.build_name >>/web && cv en $CIRCLE_PROJECT_REPONAME"
+  run_civilint:
+    description: "Run civilint"
+    parameters:
+      build_name:
+        type: string
+        default: master
+    steps:
+      - run: su - buildkit -c "cd /buildkit/build/<< parameters.build_name >>/web/sites/default/files/civicrm/ext/$CIRCLE_PROJECT_REPONAME && find . -type f -not -path './vendor/*' | civilint"
+  run_phpunit:
+    description: "Run PHPUnit"
+    parameters:
+      build_name:
+        type: string
+        default: master
+    steps:
+      - run: |
+          mkdir -p /phpunit
+          chown buildkit:buildkit /phpunit
+          su - buildkit -c "cd /buildkit/build/<< parameters.build_name >>/web/sites/default/files/civicrm/ext/$CIRCLE_PROJECT_REPONAME && /buildkit/bin/phpunit5 --log-junit /phpunit/<< parameters.build_name >>/junit.xml"
+  run_all:
+    description: "Run all steps"
+    parameters:
+      build_name:
+        type: string
+        default: master
+      type:
+        type: string
+        default: drupal-clean
+      version:
+        type: string
+        default: master
+      url:
+        type: string
+        default: http://localhost:8080
+    steps:
+      - install_civicrm:
+          build_name: << parameters.build_name >>
+          type: << parameters.type >>
+          version: << parameters.version >>
+          url: << parameters.url >>
+      - install_dependencies:
+          build_name: << parameters.build_name >>
+      - install_extension:
+          build_name: << parameters.build_name >>
+      - run_civilint:
+          build_name: << parameters.build_name >>
+      - run_phpunit:
+          build_name: << parameters.build_name >>
+      - store_test_results:
+          path: /phpunit
+      - store_artifacts:
+          path: /phpunit
+
+executors:
+  civicrm:
+    docker:
+      - image: michaelmcandrew/civicrm-buildkit
+        name: civicrm
+        environment:
+          TERM: xterm-color
+          APACHE_RUN_USER: buildkit
+      - image: mysql:5.7
+        name: mysql
+        environment:
+          MYSQL_ROOT_PASSWORD: buildkit
+
+jobs:
+  build_mysql_5_7:
+    executor: civicrm
+    steps:
+      - checkout
+      - run_all
+      - run_all:
+          build_name: civi-stable
+          version: "stable"
+          url: http://localhost:8081
+      - run_all:
+          build_name: civi-5.19
+          version: "5.19"
+          url: http://localhost:8082
+      - run_all:
+          build_name: civi-5.13
+          version: "5.13"
+          url: http://localhost:8083
+      - run_all:
+          build_name: civi-5.7
+          version: "5.7"
+          url: http://localhost:8084
+  build_mariadb_10_2:
+    executor: civicrm
+    docker:
+      - image: michaelmcandrew/civicrm-buildkit
+        name: civicrm
+        environment:
+          TERM: xterm-color
+          APACHE_RUN_USER: buildkit
+      - image: mariadb:10.2
+        name: mysql
+        environment:
+          MYSQL_ROOT_PASSWORD: buildkit
+    steps:
+      - checkout
+      - run_all
+      - run_all:
+          build_name: civi-stable
+          version: "stable"
+          url: http://localhost:8081
+      - run_all:
+          build_name: civi-5.19
+          version: "5.19"
+          url: http://localhost:8082
+      - run_all:
+          build_name: civi-5.13
+          version: "5.13"
+          url: http://localhost:8083
+      - run_all:
+          build_name: civi-5.7
+          version: "5.7"
+          url: http://localhost:8084
+  build_mariadb_10_3:
+    executor: civicrm
+    docker:
+      - image: michaelmcandrew/civicrm-buildkit
+        name: civicrm
+        environment:
+          TERM: xterm-color
+          APACHE_RUN_USER: buildkit
+      - image: mariadb:10.3
+        name: mysql
+        environment:
+          MYSQL_ROOT_PASSWORD: buildkit
+    steps:
+      - checkout
+      - run_all
+      - run_all:
+          build_name: civi-stable
+          version: "stable"
+          url: http://localhost:8081
+      - run_all:
+          build_name: civi-5.19
+          version: "5.19"
+          url: http://localhost:8082
+      - run_all:
+          build_name: civi-5.13
+          version: "5.13"
+          url: http://localhost:8083
+      - run_all:
+          build_name: civi-5.7
+          version: "5.7"
+          url: http://localhost:8084
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build_mysql_5_7
+      - build_mariadb_10_2
+      - build_mariadb_10_3
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 5 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build_mysql_5_7
+      - build_mariadb_10_2
+      - build_mariadb_10_3

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Contracts
 
+[![CircleCI](https://circleci.com/gh/systopia/de.systopia.contract.svg?style=svg)](https://circleci.com/gh/systopia/de.systopia.contract)
+
 ## Downloading contract files
 
 The membership_contract custom field in membership_general custom group can hold

--- a/tests/phpunit/CRM/Contract/ContractTestBase.php
+++ b/tests/phpunit/CRM/Contract/ContractTestBase.php
@@ -22,7 +22,9 @@ use Civi\Test\TransactionalInterface;
  */
 class CRM_Contract_ContractTestBase extends \PHPUnit_Framework_TestCase implements HeadlessInterface, HookInterface, TransactionalInterface
 {
-  use Api3TestTrait;
+  use Api3TestTrait {
+    callAPISuccess as public traitCallAPISuccess;
+  }
 
   protected static $counter = 0;
 
@@ -378,4 +380,25 @@ class CRM_Contract_ContractTestBase extends \PHPUnit_Framework_TestCase implemen
   public function stripActivitySubjectID(&$subject) {
     $subject = preg_replace('/^id[0-9]+[:.]/', 'CONTRACT_ID', $subject);
   }
+
+  /**
+   * Remove 'xdebug' result key set by Civi\API\Subscriber\XDebugSubscriber
+   *
+   * This breaks some tests when xdebug is present, and we don't need it.
+   *
+   * @param $entity
+   * @param $action
+   * @param $params
+   * @param null $checkAgainst
+   *
+   * @return array|int
+   */
+  public function callAPISuccess($entity, $action, $params, $checkAgainst = NULL) {
+    $result = $this->traitCallAPISuccess($entity, $action, $params, $checkAgainst);
+    if (is_array($result)) {
+      unset($result['xdebug']);
+    }
+    return $result;
+  }
+
 }


### PR DESCRIPTION
Add continuous integration via Circle CI. This involves setting up extension dependencies. Since Civi has no comprehensive system for versioned extension dependencies yet, the current approach is to just use the master branch. This has the added benefit of catching regressions caused by dependency changes early.

Tests run against CiviCRM master, stable, 5.19, 5.13 and 5.7.