### PR TITLE
Fix conflict and error handling

### DIFF
--- a/CRM/Contract/Change.php
+++ b/CRM/Contract/Change.php
@@ -139,6 +139,18 @@ abstract class CRM_Contract_Change implements  CRM_Contract_Change_SubjectRender
     }
   }
 
+  public function verifyStatusChange() {
+    $class = get_class($this);
+    if (!method_exists($class, 'getStartStatusList')) {
+      return;
+    }
+    $contract = $this->getContract();
+    $status_name = CRM_Contract_Utils::getMembershipStatusName($contract['status_id']);
+    if (!in_array($status_name, $class::getStartStatusList())) {
+      throw new Exception("Cannot {$this->getActionName()} a membership when its status is '{$status_name}'.");
+    }
+  }
+
   /**
    * Get the change ID
    */

--- a/CRM/Contract/Change.php
+++ b/CRM/Contract/Change.php
@@ -415,7 +415,7 @@ abstract class CRM_Contract_Change implements  CRM_Contract_Change_SubjectRender
   public function checkForConflicts() {
     // TODO: refactor CRM_Contract_Handler_ModificationConflicts
     $conflictHandler = new CRM_Contract_Handler_ModificationConflicts();
-    $conflictHandler->checkForConflicts($this->data['id']);
+    $conflictHandler->checkForConflicts($this->getContractID());
   }
 
   /**

--- a/CRM/Contract/Change/Cancel.php
+++ b/CRM/Contract/Change/Cancel.php
@@ -146,7 +146,7 @@ class CRM_Contract_Change_Cancel extends CRM_Contract_Change {
    * @return array list of membership status names
    */
   public static function getStartStatusList() {
-    return ['Paused', 'New', 'Grace', 'Current', 'Pending'];
+    return ['New', 'Grace', 'Current', 'Pending'];
   }
 
   /**

--- a/CRM/Contract/Change/Resume.php
+++ b/CRM/Contract/Change/Resume.php
@@ -86,22 +86,4 @@ class CRM_Contract_Change_Resume extends CRM_Contract_Change {
     return E::ts("Resume Contract");
   }
 
-  /**
-   * Modify action links provided to the user for a given membership
-   *
-   * @param $links                array  currently given links
-   * @param $current_status_name  string membership status as a string
-   * @param $membership_data      array  all known information on the membership in question
-   */
-  public static function modifyMembershipActionLinks(&$links, $current_status_name, $membership_data) {
-    if (in_array($current_status_name, self::getStartStatusList())) {
-      $links[] = [
-          'name'  => E::ts("Resume"),
-          'title' => self::getChangeTitle(),
-          'url'   => "civicrm/contract/modify",
-          'bit'   => CRM_Core_Action::UPDATE,
-          'qs'    => "modify_action=resume&id=%%id%%",
-      ];
-    }
-  }
 }

--- a/CRM/Contract/Handler/ModificationConflicts.php
+++ b/CRM/Contract/Handler/ModificationConflicts.php
@@ -11,6 +11,7 @@
 class CRM_Contract_Handler_ModificationConflicts{
 
   private $scheduledModifications = [];
+  private $contractId = NULL;
 
   function __construct(){
     $this->needsReviewStatusId = civicrm_api3('OptionValue', 'getvalue', [ 'return' => "value", 'option_group_id' => "activity_status", 'name' => 'Needs Review']);;
@@ -37,7 +38,7 @@ class CRM_Contract_Handler_ModificationConflicts{
 
     $this->whitelistPauseResume();
 
-    if(count($this->scheduledModifications)){
+    if(count($this->scheduledModifications)) {
       foreach($this->scheduledModifications as $scheduledModification){
         if($scheduledModification['status_id'] != $this->needsReviewStatusId){
           $this->markForReview($scheduledModification['id']);

--- a/CRM/Contract/Utils.php
+++ b/CRM/Contract/Utils.php
@@ -254,4 +254,9 @@ class CRM_Contract_Utils
       }
     }
   }
+
+  public static function formatExceptionForActivityDetails(Exception $e) {
+    return "Error was: {$e->getMessage()}<br><pre>{$e->getTraceAsString()}</pre>";
+  }
+
 }

--- a/CRM/Contract/Utils.php
+++ b/CRM/Contract/Utils.php
@@ -259,4 +259,8 @@ class CRM_Contract_Utils
     return "Error was: {$e->getMessage()}<br><pre>{$e->getTraceAsString()}</pre>";
   }
 
+  public static function formatExceptionForApi(Exception $e) {
+    return $e->getMessage() . "\r\n" . $e->getTraceAsString();
+  }
+
 }

--- a/api/v3/Contract/Modify.php
+++ b/api/v3/Contract/Modify.php
@@ -44,7 +44,6 @@ function _civicrm_api3_Contract_modify_spec(&$params){
  * Schedule a new Contract modification
  */
 function civicrm_api3_Contract_modify($params) {
-  
   // set default date ('api.default' doesn't seem to work)
   if (empty($params['date'])) {
     $params['date'] = 'now';

--- a/api/v3/Contract/ProcessScheduledModifications.php
+++ b/api/v3/Contract/ProcessScheduledModifications.php
@@ -87,8 +87,9 @@ function civicrm_api3_Contract_process_scheduled_modifications($params) {
     } catch (Exception $ex) {
       // verification failed
       $change->setStatus('Failed');
-      $change->setParameter('details', "Error was: " . $ex->getMessage());
+      $change->setParameter('details', CRM_Contract_Utils::formatExceptionForActivityDetails($ex));
       $change->save();
+      // TODO: set $result?
       continue;
     }
 
@@ -110,7 +111,9 @@ function civicrm_api3_Contract_process_scheduled_modifications($params) {
       // something went wrong...
       $result['failed'][] = $change->getID();
       $result['error_details'][$change->getID()] = $ex->getMessage() . "\r\n" . $ex->getTraceAsString();
-
+      $change->setStatus('Failed');
+      $change->setParameter('details', CRM_Contract_Utils::formatExceptionForActivityDetails($ex));
+      $change->save();
     } finally {
       CRM_Contract_Configuration::enableMonitoring();
     }

--- a/api/v3/Contract/ProcessScheduledModifications.php
+++ b/api/v3/Contract/ProcessScheduledModifications.php
@@ -103,6 +103,9 @@ function civicrm_api3_Contract_process_scheduled_modifications($params) {
       // maybe we need to do some cleanup:
       CRM_Contract_Utils::deleteSystemActivities($change->getContractID());
 
+      // check for new conflicts
+      $change->checkForConflicts();
+
     } catch (Exception $ex) {
       // something went wrong...
       $result['failed'][] = $change->getID();

--- a/api/v3/Contract/ProcessScheduledModifications.php
+++ b/api/v3/Contract/ProcessScheduledModifications.php
@@ -84,12 +84,14 @@ function civicrm_api3_Contract_process_scheduled_modifications($params) {
       // verify the data before execution
       $change->populateData();
       $change->verifyData();
+      $change->verifyStatusChange();
     } catch (Exception $ex) {
       // verification failed
+      $result['failed'][] = $change->getID();
+      $result['error_details'][$change->getID()] = CRM_Contract_Utils::formatExceptionForApi($ex);
       $change->setStatus('Failed');
       $change->setParameter('details', CRM_Contract_Utils::formatExceptionForActivityDetails($ex));
       $change->save();
-      // TODO: set $result?
       continue;
     }
 
@@ -110,7 +112,7 @@ function civicrm_api3_Contract_process_scheduled_modifications($params) {
     } catch (Exception $ex) {
       // something went wrong...
       $result['failed'][] = $change->getID();
-      $result['error_details'][$change->getID()] = $ex->getMessage() . "\r\n" . $ex->getTraceAsString();
+      $result['error_details'][$change->getID()] = CRM_Contract_Utils::formatExceptionForApi($ex);
       $change->setStatus('Failed');
       $change->setParameter('details', CRM_Contract_Utils::formatExceptionForActivityDetails($ex));
       $change->save();

--- a/tests/phpunit/CRM/Contract/BasicEngineTest.php
+++ b/tests/phpunit/CRM/Contract/BasicEngineTest.php
@@ -185,17 +185,12 @@ class CRM_Contract_BasicEngineTest extends CRM_Contract_ContractTestBase {
       'membership_payment.membership_annual' => '123.00',
     ]);
     // run engine for tomorrow
-    $result = $this->callAPISuccess('Contract', 'process_scheduled_modifications', [
-      'now' => '+1 days',
-      'id'  => $contract['id']
-    ])['values'];
-    $this->assertEquals(1, count($result['failed']), 'Should report one failed update');
-    $activityId = $result['failed'][0];
-    $this->assertContains(
-      'Expected one BankingAccount',
-      $result['error_details'][$activityId],
-      'Should contain error details'
+    $result = $this->callEngineFailure(
+      $contract['id'],
+      '+1 days',
+      "Expected one BankingAccount"
     );
+    $activityId = $result['failed'][0];
     // contract update activity should be status failed and details should contain error
     $this->callAPISuccess('Activity', 'getsingle', [
       'id'        => $activityId,
@@ -207,6 +202,66 @@ class CRM_Contract_BasicEngineTest extends CRM_Contract_ContractTestBase {
       $contract,
       $contract_changed,
       'Contract shouldn\'t have changed after failure'
+    );
+  }
+
+  /**
+   * Test that cancellations of already-cancelled memberships aren't allowed
+   */
+  public function testAllowedStatusChangeCancellation() {
+    // create a new contract
+    $contract = $this->createNewContract();
+
+    // schedule cancel
+    $this->modifyContract($contract['id'], 'cancel', '+1 days', [
+      'membership_cancellation.membership_cancel_reason' => 'Unknown'
+    ]);
+    // also schedule an update a week from now
+    $this->modifyContract($contract['id'], 'update', '+7 days', [
+      'membership_payment.membership_annual' => '123.00',
+    ]);
+    // resolve "Needs Review"
+    CRM_Core_DAO::executeQuery("UPDATE civicrm_activity SET status_id = 1 WHERE source_record_id = {$contract['id']} AND status_id <> 2;");
+    // run the cancellation (but not the update)
+    $this->runContractEngine($contract['id'], '+2 days');
+
+    $contract_changed = $this->getContract($contract['id']);
+    $this->assertEquals(
+      'Cancelled',
+      CRM_Contract_Utils::getMembershipStatusName($contract_changed['status_id']),
+      'Membership should be cancelled'
+    );
+
+    // cancel contract again (while it's already cancelled)
+    $this->modifyContract($contract['id'], 'cancel', '+1 days', [
+      'membership_cancellation.membership_cancel_reason' => 'Unknown'
+    ]);
+    // resolve "Needs Review"
+    CRM_Core_DAO::executeQuery("UPDATE civicrm_activity SET status_id = 1 WHERE source_record_id = {$contract['id']} AND status_id <> 2;");
+    // run cancellation
+    $this->callEngineFailure(
+      $contract['id'],
+      '+2 days',
+      "Cannot cancel a membership when its status is 'Cancelled'"
+    );
+  }
+
+  /**
+   * Test that reviving active memberships is not possible
+   */
+  public function testAllowedStatusChangeRevive() {
+    // create a new contract
+    $contract = $this->createNewContract();
+
+    // schedule revive
+    $this->modifyContract($contract['id'], 'revive', '+1 days', [
+      'membership_payment.membership_annual' => '123.00',
+    ]);
+    // run revive
+    $this->callEngineFailure(
+      $contract['id'],
+      '+2 days',
+      "Cannot revive a membership when its status is 'Current'"
     );
   }
 

--- a/tests/phpunit/CRM/Contract/ContractTestBase.php
+++ b/tests/phpunit/CRM/Contract/ContractTestBase.php
@@ -80,6 +80,30 @@ class CRM_Contract_ContractTestBase extends \PHPUnit_Framework_TestCase implemen
     return $result;
   }
 
+  /**
+   * Run the contract engine and expect a failure
+   *
+   * @param $contract_id
+   * @param string $now
+   * @param string $expectedError
+   */
+  public function callEngineFailure($contract_id, $now = 'now', $expectedError = NULL) {
+    $result = $this->callAPISuccess('Contract', 'process_scheduled_modifications', [
+      'now' => $now,
+      'id'  => $contract_id
+    ])['values'];
+    $this->assertNotEmpty($result['failed'], "Contract Engine should report failure(s)");
+    if (!is_null($expectedError)) {
+      $errorDetails = implode("\n", $result['error_details']);
+      $this->assertContains(
+        $expectedError,
+        $errorDetails,
+        '$expectedError should be included in error_details'
+      );
+    }
+    return $result;
+  }
+
 
   /**
    * Create a new contact with a random email address. Good for simple


### PR DESCRIPTION
This fixes various issues in conflict and error handling:

- `CRM_Contract_Change::checkForConflicts()` was passing the activity ID of a modification to `CRM_Contract_Handler_ModificationConflicts`, which expected the contract ID instead.
- `CRM_Contract_Change::checkForConflicts()` was not called after a change was executed
- Exceptions encountered during execution of contract changes didn't cause the change activity to be set to status "Failed"
- Exceptions encountered prior to the execution of contract changes weren't reported back by `Contract.process_scheduled_modifications`
- Status changes were performed even if they didn't make sense (e.g. cancelling an already-cancelled membership) when processing contract changes

Includes unit tests for these issues.