### PR TITLE
GP-6589 Add submitOnce attribute for all form buttons

### DIFF
--- a/CRM/Contract/Form/Create.php
+++ b/CRM/Contract/Form/Create.php
@@ -8,9 +8,9 @@
 | http://www.systopia.de/                                      |
 +--------------------------------------------------------------*/
 
-class CRM_Contract_Form_Create extends CRM_Core_Form{
+class CRM_Contract_Form_Create extends CRM_Core_Form {
 
-  function buildQuickForm(){
+  function buildQuickForm() {
 
 
     $this->cid = CRM_Utils_Request::retrieve('cid', 'Integer');
@@ -100,8 +100,8 @@ class CRM_Contract_Form_Create extends CRM_Core_Form{
 
 
     $this->addButtons([
-      array('type' => 'cancel', 'name' => 'Cancel'),
-      array('type' => 'submit', 'name' => 'Create')
+      ['type' => 'cancel', 'name' => 'Cancel', 'submitOnce' => TRUE],
+      ['type' => 'submit', 'name' => 'Create', 'submitOnce' => TRUE],
     ]);
 
     $this->setDefaults();
@@ -143,7 +143,7 @@ class CRM_Contract_Form_Create extends CRM_Core_Form{
   }
 
 
-  function setDefaults($defaultValues = null, $filter = null){
+  function setDefaults($defaultValues = null, $filter = null) {
 
     list($defaults['join_date'], $null) = CRM_Utils_Date::setDateDefaults(NULL, 'activityDateTime');
     list($defaults['start_date'], $null) = CRM_Utils_Date::setDateDefaults(NULL, 'activityDateTime');
@@ -156,7 +156,7 @@ class CRM_Contract_Form_Create extends CRM_Core_Form{
     parent::setDefaults($defaults);
   }
 
-  function postProcess(){
+  function postProcess() {
     $submitted = $this->exportValues();
 
     if ($submitted['payment_option'] == 'create') {

--- a/CRM/Contract/Form/Modify.php
+++ b/CRM/Contract/Form/Modify.php
@@ -109,10 +109,10 @@ class CRM_Contract_Form_Modify extends CRM_Core_Form{
       $this->addPauseFields();
     }
 
-    $this->addButtons(array(
-        array('type' => 'cancel', 'name' => 'Discard changes'), // since Cancel looks bad when viewed next to the Cancel action
-        array('type' => 'submit', 'name' => $this->change_class::getChangeTitle(), 'isDefault' => true)
-    ));
+    $this->addButtons([
+      ['type' => 'cancel', 'name' => 'Discard changes', 'submitOnce' => TRUE], // since Cancel looks bad when viewed next to the Cancel action
+      ['type' => 'submit', 'name' => $this->change_class::getChangeTitle(), 'isDefault' => true, 'submitOnce' => TRUE],
+    ]);
 
     $this->setDefaults();
   }

--- a/CRM/Contract/Form/RapidCreate/AT.php
+++ b/CRM/Contract/Form/RapidCreate/AT.php
@@ -129,9 +129,9 @@ class CRM_Contract_Form_RapidCreate_AT extends CRM_Core_Form{
 
 
     $this->addButtons([
-      ['type' => 'submit', 'name' => 'Save', 'subName' => 'done', 'isDefault' => TRUE, 'icon' => 'check'],
-      ['type' => 'submit', 'name' => 'Save and new', 'subName' => 'new'],
-      ['type' => 'cancel', 'name' => 'Cancel'],
+      ['type' => 'submit', 'name' => 'Save', 'subName' => 'done', 'isDefault' => TRUE, 'icon' => 'check', 'submitOnce' => TRUE],
+      ['type' => 'submit', 'name' => 'Save and new', 'subName' => 'new', 'submitOnce' => TRUE],
+      ['type' => 'cancel', 'name' => 'Cancel', 'submitOnce' => TRUE],
     ]);
 
     $this->setDefaults();

--- a/CRM/Contract/Form/RapidCreate/PL.php
+++ b/CRM/Contract/Form/RapidCreate/PL.php
@@ -122,9 +122,9 @@ class CRM_Contract_Form_RapidCreate_PL extends CRM_Core_Form {
 
 
     $this->addButtons([
-      ['type' => 'submit', 'name' => 'Save', 'subName' => 'done', 'isDefault' => TRUE, 'icon' => 'check'],
-      ['type' => 'submit', 'name' => 'Save and new', 'subName' => 'new'],
-      ['type' => 'cancel', 'name' => 'Cancel'],
+      ['type' => 'submit', 'name' => 'Save', 'subName' => 'done', 'isDefault' => TRUE, 'icon' => 'check', 'submitOnce' => TRUE],
+      ['type' => 'submit', 'name' => 'Save and new', 'subName' => 'new', 'submitOnce' => TRUE],
+      ['type' => 'cancel', 'name' => 'Cancel', 'submitOnce' => TRUE],
     ]);
 
     $this->setDefaults();


### PR DESCRIPTION
This adds the `submitOnce` attribute to all form buttons to prevent accidental double-submission.