### PR TITLE
Update dependencies in CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,47 +128,16 @@ jobs:
           version: "stable"
           url: http://localhost:8081
       - run_all:
-          build_name: civi-5.19
-          version: "5.19"
+          build_name: civi-5.27
+          version: "5.27"
           url: http://localhost:8082
       - run_all:
-          build_name: civi-5.13
-          version: "5.13"
+          build_name: civi-5.24
+          version: "5.24"
           url: http://localhost:8083
       - run_all:
-          build_name: civi-5.7
-          version: "5.7"
-          url: http://localhost:8084
-  build_mariadb_10_2:
-    executor: civicrm
-    docker:
-      - image: michaelmcandrew/civicrm-buildkit
-        name: civicrm
-        environment:
-          TERM: xterm-color
-          APACHE_RUN_USER: buildkit
-      - image: mariadb:10.2
-        name: mysql
-        environment:
-          MYSQL_ROOT_PASSWORD: buildkit
-    steps:
-      - checkout
-      - run_all
-      - run_all:
-          build_name: civi-stable
-          version: "stable"
-          url: http://localhost:8081
-      - run_all:
-          build_name: civi-5.19
-          version: "5.19"
-          url: http://localhost:8082
-      - run_all:
-          build_name: civi-5.13
-          version: "5.13"
-          url: http://localhost:8083
-      - run_all:
-          build_name: civi-5.7
-          version: "5.7"
+          build_name: civi-5.21
+          version: "5.21"
           url: http://localhost:8084
   build_mariadb_10_3:
     executor: civicrm
@@ -190,16 +159,47 @@ jobs:
           version: "stable"
           url: http://localhost:8081
       - run_all:
-          build_name: civi-5.19
-          version: "5.19"
+          build_name: civi-5.27
+          version: "5.27"
           url: http://localhost:8082
       - run_all:
-          build_name: civi-5.13
-          version: "5.13"
+          build_name: civi-5.24
+          version: "5.24"
           url: http://localhost:8083
       - run_all:
-          build_name: civi-5.7
-          version: "5.7"
+          build_name: civi-5.21
+          version: "5.21"
+          url: http://localhost:8084
+  build_mariadb_10_4:
+    executor: civicrm
+    docker:
+      - image: michaelmcandrew/civicrm-buildkit
+        name: civicrm
+        environment:
+          TERM: xterm-color
+          APACHE_RUN_USER: buildkit
+      - image: mariadb:10.4
+        name: mysql
+        environment:
+          MYSQL_ROOT_PASSWORD: buildkit
+    steps:
+      - checkout
+      - run_all
+      - run_all:
+          build_name: civi-stable
+          version: "stable"
+          url: http://localhost:8081
+      - run_all:
+          build_name: civi-5.27
+          version: "5.27"
+          url: http://localhost:8082
+      - run_all:
+          build_name: civi-5.24
+          version: "5.24"
+          url: http://localhost:8083
+      - run_all:
+          build_name: civi-5.21
+          version: "5.21"
           url: http://localhost:8084
 
 workflows:
@@ -207,5 +207,5 @@ workflows:
   build:
     jobs:
       - build_mysql_5_7
-      - build_mariadb_10_2
       - build_mariadb_10_3
+      - build_mariadb_10_4


### PR DESCRIPTION
This changes our text matrix in CI:
- Drop Civi 5.7 and Civi 5.13 - tests started failing due to PHP being upgraded in the docker image
- Add Civi 5.21 (old ESR), Civi 5.24 and Civi 5.27 (ESR)
- Switch from MariaDB 10.2 and 10.3 to 10.3 and 10.4

Tests now run against master, stable, 5.27, 5.24 and 5.21.