### PR TITLE
#17027 Contract Create: set ch_annual_diff only if notset or empty

### DIFF
--- a/CRM/Contract/Change/Sign.php
+++ b/CRM/Contract/Change/Sign.php
@@ -37,7 +37,7 @@ class CRM_Contract_Change_Sign extends CRM_Contract_Change {
   public function populateData() {
     parent::populateData();
     $contract = $this->getContract(TRUE);
-    if ( (!isset($this->data['contract_updates.ch_annual_diff'])) or (empty($this->data['contract_updates.ch_annual_diff']))) {
+    if (!isset($this->data['contract_updates.ch_annual_diff'])) {
         $this->data['contract_updates.ch_annual_diff'] = CRM_Utils_Array::value('membership_payment.membership_annual', $contract, '');
     }
   }

--- a/CRM/Contract/Change/Sign.php
+++ b/CRM/Contract/Change/Sign.php
@@ -37,7 +37,9 @@ class CRM_Contract_Change_Sign extends CRM_Contract_Change {
   public function populateData() {
     parent::populateData();
     $contract = $this->getContract(TRUE);
-    $this->data['contract_updates.ch_annual_diff'] = CRM_Utils_Array::value('membership_payment.membership_annual', $contract, '');
+    if ( (!isset($this->data['contract_updates.ch_annual_diff'])) or (empty($this->data['contract_updates.ch_annual_diff']))) {
+        $this->data['contract_updates.ch_annual_diff'] = CRM_Utils_Array::value('membership_payment.membership_annual', $contract, '');
+    }
   }
 
 


### PR DESCRIPTION
This change prevents overwriting of the API-Parameter custom_ch_annual_diff for an Call to Contract.Create.
If you have explicitly set custom_ch_annual_diff you don't want it to be overwritten internally.
