### PR TITLE
Add Formprocessor Actions to Contract Extension

### DIFF
--- a/Civi/Contract/ActionProvider/Action/CancelContract.php
+++ b/Civi/Contract/ActionProvider/Action/CancelContract.php
@@ -1,0 +1,137 @@
+<?php
+/*-------------------------------------------------------+
+| Project 60 - SEPA direct debit                         |
+| Copyright (C) 2019 SYSTOPIA                            |
+| Author: B. Endres (endres -at- systopia.de)            |
+| http://www.systopia.de/                                |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++--------------------------------------------------------*/
+
+namespace Civi\Contract\ActionProvider\Action;
+
+use \Civi\ActionProvider\Action\AbstractAction;
+use \Civi\ActionProvider\Parameter\ParameterBagInterface;
+use \Civi\ActionProvider\Parameter\Specification;
+use \Civi\ActionProvider\Parameter\SpecificationBag;
+
+use CRM_Contract_ExtensionUtil as E;
+
+class CancelContract extends AbstractAction {
+
+  /**
+   * Returns the specification of the configuration options for the actual action.
+   *
+   * @return SpecificationBag specs
+   */
+  public function getConfigurationSpecification() {
+    return new SpecificationBag([
+        new Specification('default_membership_type_id',       'Integer', E::ts('Membership Type ID (default)'), true, null, null, $this->getMembershipTypes(), false),
+        new Specification('default_membership_cancellation.membership_cancel_reason',       'Integer', E::ts('Cancel Reason (default)'), true, null, null, $this->getCancelReasons(), false),
+
+    ]);
+  }
+
+  /**
+   * Returns the specification of the parameters of the actual action.
+   *
+   * @return SpecificationBag specs
+   */
+  public function getParameterSpecification() {
+    return new SpecificationBag([
+        // required fields
+        new Specification('contact_id', 'Integer', E::ts('Contact ID'), false),
+        new Specification('contract_id', 'Integer', E::ts('Contract ID'), true),
+        new Specification('date',            'Date', E::ts('Date'),  true, date('Y-m-d H:i:s')),
+        new Specification('membership_type_id',       'Integer', E::ts('Membership Type ID'), false),
+        new Specification('membership_cancellation.membership_cancel_reason',       'Integer', E::ts('Cancel Reason'), false),
+
+        // dates
+
+    ]);
+  }
+
+  /**
+   * Returns the specification of the output parameters of this action.
+   *
+   * This function could be overridden by child classes.
+   *
+   * @return SpecificationBag specs
+   */
+  public function getOutputSpecification() {
+    return new SpecificationBag([
+      new Specification('contract_id',        'Integer', E::ts('Contract ID'), false, null, null, null, false),
+      new Specification('error',             'String',  E::ts('Error Message (if creation failed)'), false, null, null, null, false),
+    ]);
+  }
+
+  /**
+   * Run the action
+   *
+   * @param ParameterBagInterface $parameters
+   *   The parameters to this action.
+   * @param ParameterBagInterface $output
+   * 	 The parameters this action can send back
+   * @return void
+   */
+  protected function doAction(ParameterBagInterface $parameters, ParameterBagInterface $output) {
+    $contract_data = ['action' => 'cancel'];
+
+    // add basic fields to contract_data
+    foreach (['contact_id','contract_id','membership_type_id','date','membership_cancellation.membership_cancel_reason'] as $parameter_name) {
+      $value = $parameters->getParameter($parameter_name);
+      if (!empty($value)) {
+        $contract_data[$parameter_name] = $value;
+      }
+    }
+    // add override fields to contract_data
+    foreach (['membership_type_id','membership_cancellation.membership_cancel_reason'] as $parameter_name) {
+      $value = $parameters->getParameter($parameter_name);
+      if (empty($value)) {
+        $value = $this->configuration->getParameter("default_{$parameter_name}");
+      }
+      $contract_data[$parameter_name] = $value;
+    }
+
+
+    // create mandate
+    try {
+      $contract = \civicrm_api3('Contract', 'modify', $contract_data);
+      $output->setParameter('contract_id', $contract['id']);
+    } catch (\Exception $ex) {
+      $output->setParameter('contract_id', '');
+      $output->setParameter('error', $ex->getMessage());
+    }
+  }
+
+  /**
+   * Get a list of all membership types
+   */
+  protected function getMembershipTypes() {
+    $creditor_list = [];
+    $creditor_query = \civicrm_api3('MembershipType', 'get', ['option.limit' => 0]);
+    foreach ($creditor_query['values'] as $creditor) {
+      $creditor_list[$creditor['id']] = $creditor['name'];
+    }
+    return $creditor_list;
+  }
+
+   /**
+   * Get a list of cancel reasons
+   */
+  protected function getCancelReasons() {
+    $cancel_reasons = [];
+    $query = \civicrm_api3('OptionValue', 'get', ['option_group_id' => 'contract_cancel_reason', 'option.limit' => 0]);
+    foreach ($query['values'] as $reason) {
+      $cancel_reasons[$reason['value']] = $reason['name'];
+    }
+    return $cancel_reasons;
+  }
+
+}

--- a/Civi/Contract/ActionProvider/Action/CreateContract.php
+++ b/Civi/Contract/ActionProvider/Action/CreateContract.php
@@ -1,0 +1,299 @@
+<?php
+/*-------------------------------------------------------+
+| Project 60 - SEPA direct debit                         |
+| Copyright (C) 2019 SYSTOPIA                            |
+| Author: B. Endres (endres -at- systopia.de)            |
+| http://www.systopia.de/                                |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++--------------------------------------------------------*/
+
+namespace Civi\Contract\ActionProvider\Action;
+
+use \Civi\ActionProvider\Action\AbstractAction;
+use \Civi\ActionProvider\Parameter\ParameterBagInterface;
+use \Civi\ActionProvider\Parameter\Specification;
+use \Civi\ActionProvider\Parameter\SpecificationBag;
+
+use CRM_Contract_ExtensionUtil as E;
+
+class CreateContract extends AbstractAction {
+
+  /**
+   * Returns the specification of the configuration options for the actual action.
+   *
+   * @return SpecificationBag specs
+   */
+  public function getConfigurationSpecification() {
+    return new SpecificationBag([
+        new Specification('default_membership_type_id',       'Integer', E::ts('Membership Type ID (default)'), true, null, null, $this->getMembershipTypes(), false),
+        new Specification('default_creditor_id',       'Integer', E::ts('Creditor (default)'), true, null, null, $this->getCreditors(), false),
+        new Specification('default_financial_type_id', 'Integer', E::ts('Financial Type (default)'), true, null, null, $this->getFinancialTypes(), false),
+        new Specification('default_campaign_id',       'Integer', E::ts('Campaign (default)'), false, null, null, $this->getCampaigns(), false),
+        new Specification('default_frequency',         'Integer', E::ts('Frequency (default)'), true, 12, null, $this->getFrequencies()),
+        new Specification('default_cycle_day',         'Integer', E::ts('Collection Day (default)'), false, 0, null, $this->getCollectionDays()),
+        new Specification('buffer_days',               'Integer', E::ts('Buffer Days'), true, 7),
+
+    ]);
+  }
+
+  /**
+   * Returns the specification of the parameters of the actual action.
+   *
+   * @return SpecificationBag specs
+   */
+  public function getParameterSpecification() {
+    return new SpecificationBag([
+        // required fields
+        new Specification('contact_id', 'Integer', E::ts('Contact ID'), true),
+        new Specification('membership_type_id',       'Integer', E::ts('Membership Type ID'), false),
+        new Specification('iban',       'String',  E::ts('IBAN'), true),
+        new Specification('bic',        'String',  E::ts('BIC'), true),
+        new Specification('amount',     'Money',   E::ts('Amount'), true),
+        new Specification('reference',  'String',  E::ts('Mandate Reference'), false),
+
+        // recurring information
+        new Specification('frequency',  'Integer', E::ts('Frequency'),      false, 12, null, $this->getFrequencies()),
+        new Specification('cycle_day',  'Integer', E::ts('Collection Day'), false, 1,  null, $this->getCollectionDays()),
+
+        // basic overrides
+        new Specification('creditor_id',       'Integer', E::ts('Creditor (default)'), false, null, null, $this->getCreditors(), false),
+        new Specification('financial_type_id', 'Integer', E::ts('Financial Type (default)'), false, null, null, $this->getFinancialTypes(), false),
+        new Specification('campaign_id',       'Integer', E::ts('Campaign (default)'), false, null, null, $this->getCampaigns(), false),
+
+        // dates
+        new Specification('start_date',      'Date', E::ts('Start Date'), false, date('Y-m-d H:i:s')),
+        new Specification('date',            'Date', E::ts('Signature Date'),  false, date('Y-m-d H:i:s')),
+        new Specification('validation_date', 'Date', E::ts('Validation Date'), false, date('Y-m-d H:i:s')),
+
+        # Contract stuff
+        #new Specification('membership_payment.to_ba',       'String',  E::ts('IBAN'), true),
+        #new Specification('membership_payment.membership_annual',      'Money',  E::ts('Anual Amount'), false),
+        #new Specification('membership_payment.membership_frequency',      'Integer',  E::ts('Frequency'), false),
+        #new Specification('membership_payment.cycle_day',      'Integer',  E::ts('Cycle Day'), false),
+        #new Specification('membership_type_id',       'Integer', E::ts('Membership Type ID'), false),
+    ]);
+  }
+
+  /**
+   * Returns the specification of the output parameters of this action.
+   *
+   * This function could be overridden by child classes.
+   *
+   * @return SpecificationBag specs
+   */
+  public function getOutputSpecification() {
+    return new SpecificationBag([
+      new Specification('mandate_id',        'Integer', E::ts('Mandate ID'), false, null, null, null, false),
+      new Specification('mandate_reference', 'String',  E::ts('Mandate Reference'), false, null, null, null, false),
+      new Specification('error',             'String',  E::ts('Error Message (if creation failed)'), false, null, null, null, false),
+    ]);
+  }
+
+  /**
+   * Run the action
+   *
+   * @param ParameterBagInterface $parameters
+   *   The parameters to this action.
+   * @param ParameterBagInterface $output
+   * 	 The parameters this action can send back
+   * @return void
+   */
+  protected function doAction(ParameterBagInterface $parameters, ParameterBagInterface $output) {
+    $mandate_data = ['type' => 'RCUR'];
+    // add basic fields to mandate_data
+    foreach (['contact_id', 'iban', 'bic', 'reference', 'amount', 'start_date', 'date', 'validation_date'] as $parameter_name) {
+      $value = $parameters->getParameter($parameter_name);
+      if (!empty($value)) {
+        $mandate_data[$parameter_name] = $value;
+      }
+    }
+
+    // add override fields to mandate_data
+    foreach (['creditor_id', 'financial_type_id', 'campaign_id', 'cycle_day', 'frequency'] as $parameter_name) {
+      $value = $parameters->getParameter($parameter_name);
+      if (empty($value)) {
+        $value = $this->configuration->getParameter("default_{$parameter_name}");
+      }
+      $mandate_data[$parameter_name] = $value;
+    }
+
+    // sort out frequency
+    $mandate_data['frequency_interval'] = 12 / $mandate_data['frequency'];
+    $mandate_data['frequency_unit'] = 'month';
+    unset($mandate_data['frequency']);
+
+    // verify/adjust start date
+    $buffer_days = (int) $this->configuration->getParameter('buffer_days');
+    $earliest_start_date = strtotime("+ {$buffer_days} days");
+    $current_start_date = strtotime($mandate_data['start_date']);
+    if ($current_start_date < $earliest_start_date) {
+      $mandate_data['start_date'] = date('YmdHis', $earliest_start_date);
+    }
+
+    // if not set, calculate the closest cycle day
+    if (empty($mandate_data['cycle_day'])) {
+      $mandate_data['cycle_day'] = $this->calculateSoonestCycleDay($mandate_data);
+    }
+
+    $contract_data = [];
+    // add basic fields to contract_data
+    foreach (['contact_id','membership_type_id'] as $parameter_name) {
+      $value = $parameters->getParameter($parameter_name);
+      if (!empty($value)) {
+        $contract_data[$parameter_name] = $value;
+      }
+    }
+    // add override fields to contract_data
+    foreach (['membership_type_id',] as $parameter_name) {
+      $value = $parameters->getParameter($parameter_name);
+      if (empty($value)) {
+        $value = $this->configuration->getParameter("default_{$parameter_name}");
+      }
+      $contract_data[$parameter_name] = $value;
+    }
+
+
+    // create mandate
+    try {
+      $mandate = \civicrm_api3('SepaMandate', 'createfull', $mandate_data);
+      $mandate = \civicrm_api3('SepaMandate', 'getsingle', ['id' => $mandate['id'], 'return' => 'id,reference']);
+      $contract_data['membership_payment.membership_recurring_contribution'] = $mandate['id'];
+      $contract = \civicrm_api3('Contract', 'create', $contract_data);
+      $output->setParameter('mandate_id', $mandate['id']);
+      $output->setParameter('mandate_reference', $mandate['reference']);
+      #$output->setParameter('contract_id', $contract['id']);
+    } catch (\Exception $ex) {
+      $output->setParameter('mandate_id', '');
+      $output->setParameter('mandate_reference', '');
+      #$output->setParameter('contract_id', '');
+      $output->setParameter('error', $ex->getMessage());
+    }
+  }
+
+
+  /**
+   * Get a list of all membership types
+   */
+  protected function getMembershipTypes() {
+    $creditor_list = [];
+    $creditor_query = \civicrm_api3('MembershipType', 'get', ['option.limit' => 0]);
+    foreach ($creditor_query['values'] as $creditor) {
+      $creditor_list[$creditor['id']] = $creditor['name'];
+    }
+    return $creditor_list;
+  }
+
+  /**
+   * Get list of frequencies
+   */
+  protected function getFrequencies() {
+    return [
+        1  => E::ts("annually"),
+        2  => E::ts("semi-annually"),
+        4  => E::ts("quarterly"),
+        6  => E::ts("bi-monthly"),
+        12 => E::ts("monthly"),
+    ];
+  }
+
+  /**
+   * Get a list of all creditors
+   */
+  protected function getCreditors() {
+    $creditor_list = [];
+    $creditor_query = \civicrm_api3('SepaCreditor', 'get', ['option.limit' => 0]);
+    foreach ($creditor_query['values'] as $creditor) {
+      $creditor_list[$creditor['id']] = $creditor['name'];
+    }
+    return $creditor_list;
+  }
+
+    /**
+   * Get a list of all financial types
+   */
+  protected function getFinancialTypes() {
+    $list = [];
+    $query = \civicrm_api3('FinancialType', 'get', [
+        'option.limit' => 0,
+        'is_enabled'   => 1,
+        'return'       => 'id,name']);
+    foreach ($query['values'] as $entity) {
+      $list[$entity['id']] = $entity['name'];
+    }
+    return $list;
+  }
+
+    /**
+   * Get a list of all campaigns
+   */
+  protected function getCampaigns() {
+    $list = [];
+    $query = \civicrm_api3('Campaign', 'get', [
+        'option.limit' => 0,
+        'is_active'    => 1,
+        'return'       => 'id,title']);
+    foreach ($query['values'] as $entity) {
+      $list[$entity['id']] = $entity['title'];
+    }
+    return $list;
+  }
+
+  /**
+   * Get list of collection days
+   */
+  protected function getCollectionDays() {
+    $list = range(0,28);
+    $options = array_combine($list, $list);
+    $options[0] = E::ts("as soon as possible");
+    return $options;
+  }
+
+    /**
+     * Select the cycle day from the given creditor,
+     *  that allows for the soonest collection given the buffer time
+     *
+     * @param array $mandate_data
+     *      all data known about the mandate
+     *
+     */
+  protected function calculateSoonestCycleDay($mandate_data) {
+      // get creditor ID
+      $creditor_id = (int) $mandate_data['creditor_id'];
+      if (!$creditor_id) {
+          $default_creditor = \CRM_Sepa_Logic_Settings::defaultCreditor();
+          if ($default_creditor) {
+              $creditor_id = $default_creditor->id;
+          } else {
+              \Civi::log()->notice("CreateRecurringMandate action: No creditor, and no default creditor set! Using cycle day 1");
+              return 1;
+          }
+      }
+
+      // get start date
+      $date = strtotime(\CRM_Utils_Array::value('start_date', $mandate_data, date('Y-m-d')));
+
+      // get cycle days
+      $cycle_days = \CRM_Sepa_Logic_Settings::getListSetting("cycledays", range(1, 28), $creditor_id);
+
+      // iterate through the days until we hit a cycle day
+      for ($i = 0; $i < 31; $i++) {
+        if (in_array(date('j', $date), $cycle_days)) {
+            // we found our cycle_day!
+            return date('j', $date);
+        } else {
+            // no? try the next one...
+            $date = strtotime("+ 1 day", $date);
+        }
+      }
+
+      // no hit? that shouldn't happen...
+      return 1;
+  }
+}

--- a/Civi/Contract/ActionProvider/Action/GetContract.php
+++ b/Civi/Contract/ActionProvider/Action/GetContract.php
@@ -1,0 +1,152 @@
+<?php
+/*-------------------------------------------------------+
+| Project 60 - SEPA direct debit                         |
+| Copyright (C) 2019 SYSTOPIA                            |
+| Author: B. Endres (endres -at- systopia.de)            |
+| http://www.systopia.de/                                |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++--------------------------------------------------------*/
+
+namespace Civi\Contract\ActionProvider\Action;
+
+use \Civi\ActionProvider\Action\AbstractAction;
+use \Civi\ActionProvider\Parameter\ParameterBagInterface;
+use \Civi\ActionProvider\Parameter\Specification;
+use \Civi\ActionProvider\Parameter\SpecificationBag;
+
+use CRM_Contract_ExtensionUtil as E;
+use CRM_Contract_Utils as U;
+
+class GetContract extends AbstractAction {
+
+  /**
+   * Returns the specification of the configuration options for the actual action.
+   *
+   * @return SpecificationBag specs
+   */
+  public function getConfigurationSpecification() {
+    return new SpecificationBag([
+        new Specification('default_membership_type_id',       'Integer', E::ts('Membership Type ID (default)'), false, null, null, $this->getMembershipTypes(), false),
+    ]);
+  }
+
+  /**
+   * Returns the specification of the parameters of the actual action.
+   *
+   * @return SpecificationBag specs
+   */
+  public function getParameterSpecification() {
+    return new SpecificationBag([
+        // required fields
+        new Specification('contact_id', 'Integer', E::ts('Contact ID'), true),
+        new Specification('membership_type_id',       'Integer', E::ts('Membership Type ID'), false),
+
+    ]);
+  }
+
+  /**
+   * Returns the specification of the output parameters of this action.
+   *
+   * This function could be overridden by child classes.
+   *
+   * @return SpecificationBag specs
+   */
+  public function getOutputSpecification() {
+    $specifications = [
+      new Specification('contract_id',        'String', E::ts('Contract ID'), false, null, null, null, false),
+      new Specification('error',             'String',  E::ts('Error Message (if failed)'), false, null, null, null, false),
+
+      new Specification('join_date',        'Date', E::ts('Join Date'), false, null, null, null, false),
+      new Specification('start_date',        'Date', E::ts('Start Date'), false, null, null, null, false),
+    ];
+
+    $customGroupNames = [ 'membership_payment'];
+    $customGroups     = civicrm_api3('CustomGroup', 'get', ['name' => ['IN' => $customGroupNames], 'return' => 'name', 'options' => ['limit' => 1000]])['values'];
+    $customFields     = civicrm_api3('CustomField', 'get', ['custom_group_id' => ['IN' => $customGroupNames], 'options' => ['limit' => 1000]]);
+    foreach ($customFields['values'] as $c) {
+        $specifications[] = new Specification($c['name'],        'Date', E::ts($c['label']), false, null, null, null, false);
+    }
+
+    return new SpecificationBag($specifications);
+  }
+
+
+  /**
+   * Run the action
+   *
+   * @param ParameterBagInterface $parameters
+   *   The parameters to this action.
+   * @param ParameterBagInterface $output
+   * 	 The parameters this action can send back
+   * @return void
+   */
+  protected function doAction(ParameterBagInterface $parameters, ParameterBagInterface $output) {
+    $contract_data = ['active_only' => 1];
+    // add basic fields to contract_data
+    foreach (['contact_id','membership_type_id'] as $parameter_name) {
+      $value = $parameters->getParameter($parameter_name);
+      if (!empty($value)) {
+        $contract_data[$parameter_name] = $value;
+      }
+    }
+    // add override fields to contract_data
+    foreach (['membership_type_id',] as $parameter_name) {
+      $value = $parameters->getParameter($parameter_name);
+      if (empty($value)) {
+        $value = $this->configuration->getParameter("default_{$parameter_name}");
+      }
+      $contract_data[$parameter_name] = $value;
+    }
+
+    if (!function_exists('str_starts_with')) {
+      function str_starts_with($str, $start) {
+        return (@substr_compare($str, $start, 0, strlen($start))==0);
+      }
+    }
+    // get contract
+    try {
+      $contract = \civicrm_api3('Contract', 'getSingle', $contract_data);
+      $output->setParameter('contract_id', $contract['id']);
+      $output->setParameter('join_date', $contract['join_date']);
+      $output->setParameter('start_date', $contract['start_date']);
+      #$output->setParameter('membership_type_id', $contract['membership_type_id']);
+      #$output->setParameter('status_id', $contract['status_id']);
+      #$output->setParameter('is_test', $contract['is_test']);
+      #$output->setParameter('membership_name', $contract['membership_name']);
+      #$output->setParameter('relationship_name', $contract['relationship_name']);
+
+      foreach ($contract as $param => $value){
+        if (str_starts_with($param, "custom_") and (substr_count($param, '_') == 1)){
+                $name = U::getCustomFieldName($param);
+                $output->setParameter($name, $contract[$param]);
+        }
+      }
+      $output->setParameter('error', "");
+
+    } catch (\Exception $ex) {
+      $output->setParameter('contract_id', '');
+      $output->setParameter('error', $ex->getMessage());
+    }
+  }
+
+
+  /**
+   * Get a list of all membership types
+   */
+  protected function getMembershipTypes() {
+    $creditor_list = [];
+    $creditor_query = \civicrm_api3('MembershipType', 'get', ['option.limit' => 0]);
+    foreach ($creditor_query['values'] as $creditor) {
+      $creditor_list[$creditor['id']] = $creditor['name'];
+    }
+    return $creditor_list;
+  }
+
+}

--- a/Civi/Contract/ActionProvider/Action/GetContract.php
+++ b/Civi/Contract/ActionProvider/Action/GetContract.php
@@ -62,17 +62,42 @@ class GetContract extends AbstractAction {
     $specifications = [
       new Specification('contract_id',        'String', E::ts('Contract ID'), false, null, null, null, false),
       new Specification('error',             'String',  E::ts('Error Message (if failed)'), false, null, null, null, false),
-
       new Specification('join_date',        'Date', E::ts('Join Date'), false, null, null, null, false),
       new Specification('start_date',        'Date', E::ts('Start Date'), false, null, null, null, false),
+
+      # Contract custom Fields
+      new Specification('membership_annual',        'Money', E::ts('Annual Membership Contribution'), false, null, null, null, false),
+      new Specification('membership_frequency',        'Integer', E::ts('Payment Interval'), false, null, null, null, false),
+      new Specification('membership_recurring_contribution',        'Integer', E::ts('Recurring contribution/mandate'), false, null, null, null, false),
+      new Specification('from_ba',        'Integer', E::ts('Donor\'s Bank Account'), false, null, null, null, false),
+      new Specification('cycle_day',        'Integer', E::ts('Cycle day'), false, null, null, null, false),
+      new Specification('payment_instrument',        'Integer', E::ts('Payment method'), false, null, null, null, false),
+      new Specification('defer_payment_start',        'Integer', E::ts('Defer Payment Start'), false, null, null, null, false),
+
+      # Recurring Contribution
+      new Specification('amount',        'Date', E::ts('Amount'), false, null, null, null, false),
+      new Specification('currency',        'Date', E::ts('Currency'), false, null, null, null, false),
+      new Specification('frequency_unit',        'Date', E::ts('Frequency Unit'), false, null, null, null, false),
+      new Specification('frequency_interval',        'Date', E::ts('Frequency Interval'), false, null, null, null, false),
+
     ];
 
-    $customGroupNames = [ 'membership_payment'];
-    $customGroups     = civicrm_api3('CustomGroup', 'get', ['name' => ['IN' => $customGroupNames], 'return' => 'name', 'options' => ['limit' => 1000]])['values'];
-    $customFields     = civicrm_api3('CustomField', 'get', ['custom_group_id' => ['IN' => $customGroupNames], 'options' => ['limit' => 1000]]);
-    foreach ($customFields['values'] as $c) {
-        $specifications[] = new Specification($c['name'],        'Date', E::ts($c['label']), false, null, null, null, false);
-    }
+    # get custom fields of Contract
+    #$customGroupNames = [ 'membership_payment'];
+    #$customGroups     = civicrm_api3('CustomGroup', 'get', ['name' => ['IN' => $customGroupNames], 'return' => 'name', 'options' => ['limit' => 1000]])['values'];
+    #$customFields     = civicrm_api3('CustomField', 'get', ['custom_group_id' => ['IN' => $customGroupNames], 'options' => ['limit' => 1000]]);
+    #foreach ($customFields['values'] as $c) {
+    #    if (strcmp($c['name'],'membership_annual') or strcmp($c['name'],'membership_frequency') or strcmp($c['name'],'membership_recurring_contribution') or strcmp($c['name'],'from_ba')or strcmp($c['name'],'cycle_day') or strcmp($c['name'],'payment_instrument') or strcmp($c['name'],'defer_payment_start')){
+    #        # do nothing
+    #    }else{
+    #        $specifications[] = new Specification($c['name'],        'String', E::ts($c['label']), false, null, null, null, false);##
+    #
+    #       #$specifications[] = new Specification($c['name'],        $this->getDataType($c['data_type']), E::ts($c['label']), false, null, null, null, false);
+    #       #$specifications[] = new Specification(U::getCustomFieldName("custom_"+$c['id']),        'Date', U::getCustomFieldName("custom_"+$c['id']), false, null, null, null, false);
+    #      #$specifications[] = new Specification($c['name'],        'Date', E::ts($c['label']), false, null, null, null, false);#
+    #
+    #    }
+    #}
 
     return new SpecificationBag($specifications);
   }
@@ -113,21 +138,48 @@ class GetContract extends AbstractAction {
     // get contract
     try {
       $contract = \civicrm_api3('Contract', 'getSingle', $contract_data);
+
+      $recurring_contribution = \civicrm_api3('ContributionRecur', 'getSingle', ['id' => $contract[U::getCustomFieldId('membership_payment.membership_recurring_contribution')]]);
+
+
       $output->setParameter('contract_id', $contract['id']);
       $output->setParameter('join_date', $contract['join_date']);
       $output->setParameter('start_date', $contract['start_date']);
+
+
+      #
+      #if (intval($contract['membership_frequency']) != 0){
+      #  $output->setParameter('membership_amount_per_frequency', ((float)str_replace(',','.',$contract['membership_annual'])/(int)$contract['membership_frequency']));
+      #}else{
+      #  $output->setParameter('membership_amount_per_frequency', '');
+      #}
+      $output->setParameter('membership_annual', $contract[U::getCustomFieldId('membership_payment.membership_annual')]);
+      $output->setParameter('membership_frequency', $contract[U::getCustomFieldId('membership_payment.membership_frequency')]);
+      $output->setParameter('membership_recurring_contribution', $contract[U::getCustomFieldId('membership_payment.membership_recurring_contribution')]);
+      $output->setParameter('from_ba', $contract[U::getCustomFieldId('membership_payment.from_ba')]);
+      $output->setParameter('cycle_day', $contract[U::getCustomFieldId('membership_payment.cycle_day')]);
+      $output->setParameter('payment_instrument', $contract[U::getCustomFieldId('membership_payment.payment_instrument')]);
+      $output->setParameter('defer_payment_start', $contract[U::getCustomFieldId('membership_payment.defer_payment_start')]);
+
+      $output->setParameter('amount', $recurring_contribution['amount']);
+      $output->setParameter('currency', $recurring_contribution['currency']);
+      $output->setParameter('frequency_unit', $recurring_contribution['frequency_unit']);
+      $output->setParameter('frequency_interval', $recurring_contribution['frequency_interval']);
+
       #$output->setParameter('membership_type_id', $contract['membership_type_id']);
       #$output->setParameter('status_id', $contract['status_id']);
       #$output->setParameter('is_test', $contract['is_test']);
       #$output->setParameter('membership_name', $contract['membership_name']);
       #$output->setParameter('relationship_name', $contract['relationship_name']);
 
-      foreach ($contract as $param => $value){
-        if (str_starts_with($param, "custom_") and (substr_count($param, '_') == 1)){
-                $name = U::getCustomFieldName($param);
-                $output->setParameter($name, $contract[$param]);
-        }
-      }
+      #foreach ($contract as $param => $value){
+      #  if (str_starts_with($param, "custom_") and (substr_count($param, '_') == 1)){
+      #          $name = U::getCustomFieldName($param);
+      #          $name = substr($name,strpos($name,".")+1);
+      #          $output->setParameter($name, $contract[$param]);
+      #  }
+      #}
+
       $output->setParameter('error', "");
 
     } catch (\Exception $ex) {
@@ -147,6 +199,18 @@ class GetContract extends AbstractAction {
       $creditor_list[$creditor['id']] = $creditor['name'];
     }
     return $creditor_list;
+  }
+
+  /**
+  * map the datatype of custom field to a data type of formprocessor
+  */
+  protected function getDataType($customFieldDataType){
+    $dataTypeMapping = [
+        "Int" => "Integer",
+        "String" => "String",
+        "Date" => "Date",
+    ];
+    return $dataTypeMapping[$customFieldDataType];
   }
 
 }

--- a/Civi/Contract/ActionProvider/Action/GetSepaRcur.php
+++ b/Civi/Contract/ActionProvider/Action/GetSepaRcur.php
@@ -1,0 +1,98 @@
+<?php
+/*-------------------------------------------------------+
+| Project 60 - SEPA direct debit                         |
+| Copyright (C) 2019 SYSTOPIA                            |
+| Author: B. Endres (endres -at- systopia.de)            |
+| http://www.systopia.de/                                |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++--------------------------------------------------------*/
+
+namespace Civi\Contract\ActionProvider\Action;
+
+use \Civi\ActionProvider\Action\AbstractAction;
+use \Civi\ActionProvider\Parameter\ParameterBagInterface;
+use \Civi\ActionProvider\Parameter\Specification;
+use \Civi\ActionProvider\Parameter\SpecificationBag;
+
+use CRM_Contract_ExtensionUtil as E;
+use CRM_Contract_Utils as U;
+
+class GetSepaRcur extends AbstractAction {
+
+  /**
+   * Returns the specification of the configuration options for the actual action.
+   *
+   * @return SpecificationBag specs
+   */
+  public function getConfigurationSpecification() {
+    return new SpecificationBag([]);
+  }
+
+  /**
+   * Returns the specification of the parameters of the actual action.
+   *
+   * @return SpecificationBag specs
+   */
+  public function getParameterSpecification() {
+    return new SpecificationBag([
+        // required fields
+        #new Specification('contact_id', 'Integer', E::ts('Contact ID'), true),
+        new Specification('recurring_contribution_id',       'Integer', E::ts('Recurring Contribution ID'), true),
+    ]);
+  }
+
+  /**
+   * Returns the specification of the output parameters of this action.
+   *
+   * This function could be overridden by child classes.
+   *
+   * @return SpecificationBag specs
+   */
+  public function getOutputSpecification() {
+    $specifications = [
+      new Specification('reference',        'String', E::ts('Mandate Reference'), false, null, null, null, false),
+      new Specification('iban',        'Date', E::ts('IBAN'), false, null, null, null, false),
+      new Specification('bic',        'Date', E::ts('BIC'), false, null, null, null, false),
+      new Specification('error',             'String',  E::ts('Error Message (if failed)'), false, null, null, null, false),
+    ];
+
+    return new SpecificationBag($specifications);
+  }
+
+
+  /**
+   * Run the action
+   *
+   * @param ParameterBagInterface $parameters
+   *   The parameters to this action.
+   * @param ParameterBagInterface $output
+   * 	 The parameters this action can send back
+   * @return void
+   */
+  protected function doAction(ParameterBagInterface $parameters, ParameterBagInterface $output) {
+
+    // get contract
+    $mandate_params = ['entity_table' => 'civicrm_contribution_recur'];
+    $mandate_params['id'] = $parameters->getParameter('recurring_contribution_id');
+
+    try {
+      $mandate = \civicrm_api3('SepaMandate', 'getSingle', $mandate_params);
+
+      $output->setParameter('iban', $mandate['iban']);
+      $output->setParameter('bic', $mandate['bic']);
+      $output->setParameter('error', "");
+
+    } catch (\Exception $ex) {
+      $output->setParameter('iban', '');
+      $output->setParameter('bic', '');
+      $output->setParameter('error', $ex->getMessage());
+    }
+  }
+}

--- a/Civi/Contract/ActionProvider/Action/PauseContract.php
+++ b/Civi/Contract/ActionProvider/Action/PauseContract.php
@@ -1,0 +1,122 @@
+<?php
+/*-------------------------------------------------------+
+| Project 60 - SEPA direct debit                         |
+| Copyright (C) 2019 SYSTOPIA                            |
+| Author: B. Endres (endres -at- systopia.de)            |
+| http://www.systopia.de/                                |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++--------------------------------------------------------*/
+
+namespace Civi\Contract\ActionProvider\Action;
+
+use \Civi\ActionProvider\Action\AbstractAction;
+use \Civi\ActionProvider\Parameter\ParameterBagInterface;
+use \Civi\ActionProvider\Parameter\Specification;
+use \Civi\ActionProvider\Parameter\SpecificationBag;
+
+use CRM_Contract_ExtensionUtil as E;
+
+class PauseContract extends AbstractAction {
+
+  /**
+   * Returns the specification of the configuration options for the actual action.
+   *
+   * @return SpecificationBag specs
+   */
+  public function getConfigurationSpecification() {
+    return new SpecificationBag([
+        new Specification('default_membership_type_id',       'Integer', E::ts('Membership Type ID (default)'), true, null, null, $this->getMembershipTypes(), false),
+
+    ]);
+  }
+
+  /**
+   * Returns the specification of the parameters of the actual action.
+   *
+   * @return SpecificationBag specs
+   */
+  public function getParameterSpecification() {
+    return new SpecificationBag([
+        // required fields
+        new Specification('contact_id', 'Integer', E::ts('Contact ID'), false),
+        new Specification('contract_id', 'Integer', E::ts('Contract ID'), true),
+        new Specification('membership_type_id',       'Integer', E::ts('Membership Type ID'), false),
+
+        // dates
+        new Specification('date',            'Date', E::ts('Date'),  false, date('Y-m-d H:i:s')),
+        new Specification('resume_date',     'Date', E::ts('Resume Date'), false, date('Y-m-d H:i:s')),
+    ]);
+  }
+
+  /**
+   * Returns the specification of the output parameters of this action.
+   *
+   * This function could be overridden by child classes.
+   *
+   * @return SpecificationBag specs
+   */
+  public function getOutputSpecification() {
+    return new SpecificationBag([
+      new Specification('contract_id',        'Integer', E::ts('Contract ID'), false, null, null, null, false),
+      new Specification('error',             'String',  E::ts('Error Message (if creation failed)'), false, null, null, null, false),
+    ]);
+  }
+
+  /**
+   * Run the action
+   *
+   * @param ParameterBagInterface $parameters
+   *   The parameters to this action.
+   * @param ParameterBagInterface $output
+   * 	 The parameters this action can send back
+   * @return void
+   */
+  protected function doAction(ParameterBagInterface $parameters, ParameterBagInterface $output) {
+    $contract_data = ['action' => 'pause'];
+
+    // add basic fields to contract_data
+    foreach (['contact_id','contract_id','membership_type_id','date','resume_date'] as $parameter_name) {
+      $value = $parameters->getParameter($parameter_name);
+      if (!empty($value)) {
+        $contract_data[$parameter_name] = $value;
+      }
+    }
+    // add override fields to contract_data
+    foreach (['membership_type_id',] as $parameter_name) {
+      $value = $parameters->getParameter($parameter_name);
+      if (empty($value)) {
+        $value = $this->configuration->getParameter("default_{$parameter_name}");
+      }
+      $contract_data[$parameter_name] = $value;
+    }
+
+
+    // create mandate
+    try {
+      $contract = \civicrm_api3('Contract', 'modify', $contract_data);
+      $output->setParameter('contract_id', $contract['id']);
+    } catch (\Exception $ex) {
+      $output->setParameter('contract_id', '');
+      $output->setParameter('error', $ex->getMessage());
+    }
+  }
+
+  /**
+   * Get a list of all membership types
+   */
+  protected function getMembershipTypes() {
+    $creditor_list = [];
+    $creditor_query = \civicrm_api3('MembershipType', 'get', ['option.limit' => 0]);
+    foreach ($creditor_query['values'] as $creditor) {
+      $creditor_list[$creditor['id']] = $creditor['name'];
+    }
+    return $creditor_list;
+  }
+}

--- a/Civi/Contract/ActionProvider/Action/ResumeContract.php
+++ b/Civi/Contract/ActionProvider/Action/ResumeContract.php
@@ -1,0 +1,121 @@
+<?php
+/*-------------------------------------------------------+
+| Project 60 - SEPA direct debit                         |
+| Copyright (C) 2019 SYSTOPIA                            |
+| Author: B. Endres (endres -at- systopia.de)            |
+| http://www.systopia.de/                                |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++--------------------------------------------------------*/
+
+namespace Civi\Contract\ActionProvider\Action;
+
+use \Civi\ActionProvider\Action\AbstractAction;
+use \Civi\ActionProvider\Parameter\ParameterBagInterface;
+use \Civi\ActionProvider\Parameter\Specification;
+use \Civi\ActionProvider\Parameter\SpecificationBag;
+
+use CRM_Contract_ExtensionUtil as E;
+
+class ResumeContract extends AbstractAction {
+
+  /**
+   * Returns the specification of the configuration options for the actual action.
+   *
+   * @return SpecificationBag specs
+   */
+  public function getConfigurationSpecification() {
+    return new SpecificationBag([
+        new Specification('default_membership_type_id',       'Integer', E::ts('Membership Type ID (default)'), true, null, null, $this->getMembershipTypes(), false),
+
+    ]);
+  }
+
+  /**
+   * Returns the specification of the parameters of the actual action.
+   *
+   * @return SpecificationBag specs
+   */
+  public function getParameterSpecification() {
+    return new SpecificationBag([
+        // required fields
+        new Specification('contact_id', 'Integer', E::ts('Contact ID'), false),
+        new Specification('contract_id', 'Integer', E::ts('Contract ID'), true),
+        new Specification('membership_type_id',       'Integer', E::ts('Membership Type ID'), false),
+
+        // dates
+        new Specification('date',            'Date', E::ts('Date'),  false, date('Y-m-d H:i:s')),
+    ]);
+  }
+
+  /**
+   * Returns the specification of the output parameters of this action.
+   *
+   * This function could be overridden by child classes.
+   *
+   * @return SpecificationBag specs
+   */
+  public function getOutputSpecification() {
+    return new SpecificationBag([
+      new Specification('contract_id',        'Integer', E::ts('Contract ID'), false, null, null, null, false),
+      new Specification('error',             'String',  E::ts('Error Message (if creation failed)'), false, null, null, null, false),
+    ]);
+  }
+
+  /**
+   * Run the action
+   *
+   * @param ParameterBagInterface $parameters
+   *   The parameters to this action.
+   * @param ParameterBagInterface $output
+   * 	 The parameters this action can send back
+   * @return void
+   */
+  protected function doAction(ParameterBagInterface $parameters, ParameterBagInterface $output) {
+    $contract_data = ['action' => 'resume'];
+
+    // add basic fields to contract_data
+    foreach (['contact_id','contract_id','membership_type_id','date'] as $parameter_name) {
+      $value = $parameters->getParameter($parameter_name);
+      if (!empty($value)) {
+        $contract_data[$parameter_name] = $value;
+      }
+    }
+    // add override fields to contract_data
+    foreach (['membership_type_id',] as $parameter_name) {
+      $value = $parameters->getParameter($parameter_name);
+      if (empty($value)) {
+        $value = $this->configuration->getParameter("default_{$parameter_name}");
+      }
+      $contract_data[$parameter_name] = $value;
+    }
+
+
+    // create mandate
+    try {
+      $contract = \civicrm_api3('Contract', 'modify', $contract_data);
+      $output->setParameter('contract_id', $contract['id']);
+    } catch (\Exception $ex) {
+      $output->setParameter('contract_id', '');
+      $output->setParameter('error', $ex->getMessage());
+    }
+  }
+
+  /**
+   * Get a list of all membership types
+   */
+  protected function getMembershipTypes() {
+    $creditor_list = [];
+    $creditor_query = \civicrm_api3('MembershipType', 'get', ['option.limit' => 0]);
+    foreach ($creditor_query['values'] as $creditor) {
+      $creditor_list[$creditor['id']] = $creditor['name'];
+    }
+    return $creditor_list;
+  }
+}

--- a/Civi/Contract/ActionProvider/Action/ReviveContract.php
+++ b/Civi/Contract/ActionProvider/Action/ReviveContract.php
@@ -1,0 +1,121 @@
+<?php
+/*-------------------------------------------------------+
+| Project 60 - SEPA direct debit                         |
+| Copyright (C) 2019 SYSTOPIA                            |
+| Author: B. Endres (endres -at- systopia.de)            |
+| http://www.systopia.de/                                |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++--------------------------------------------------------*/
+
+namespace Civi\Contract\ActionProvider\Action;
+
+use \Civi\ActionProvider\Action\AbstractAction;
+use \Civi\ActionProvider\Parameter\ParameterBagInterface;
+use \Civi\ActionProvider\Parameter\Specification;
+use \Civi\ActionProvider\Parameter\SpecificationBag;
+
+use CRM_Contract_ExtensionUtil as E;
+
+class ReviveContract extends AbstractAction {
+
+  /**
+   * Returns the specification of the configuration options for the actual action.
+   *
+   * @return SpecificationBag specs
+   */
+  public function getConfigurationSpecification() {
+    return new SpecificationBag([
+        new Specification('default_membership_type_id',       'Integer', E::ts('Membership Type ID (default)'), true, null, null, $this->getMembershipTypes(), false),
+
+    ]);
+  }
+
+  /**
+   * Returns the specification of the parameters of the actual action.
+   *
+   * @return SpecificationBag specs
+   */
+  public function getParameterSpecification() {
+    return new SpecificationBag([
+        // required fields
+        new Specification('contact_id', 'Integer', E::ts('Contact ID'), false),
+        new Specification('contract_id', 'Integer', E::ts('Contract ID'), true),
+        new Specification('date',            'Date', E::ts('Date'),  true, date('Y-m-d H:i:s')),
+        new Specification('membership_type_id',       'Integer', E::ts('Membership Type ID'), false),
+
+    ]);
+  }
+
+  /**
+   * Returns the specification of the output parameters of this action.
+   *
+   * This function could be overridden by child classes.
+   *
+   * @return SpecificationBag specs
+   */
+  public function getOutputSpecification() {
+    return new SpecificationBag([
+      new Specification('contract_id',        'Integer', E::ts('Contract ID'), false, null, null, null, false),
+      new Specification('error',             'String',  E::ts('Error Message (if creation failed)'), false, null, null, null, false),
+    ]);
+  }
+
+  /**
+   * Run the action
+   *
+   * @param ParameterBagInterface $parameters
+   *   The parameters to this action.
+   * @param ParameterBagInterface $output
+   * 	 The parameters this action can send back
+   * @return void
+   */
+  protected function doAction(ParameterBagInterface $parameters, ParameterBagInterface $output) {
+    $contract_data = ['action' => 'revive'];
+
+    // add basic fields to contract_data
+    foreach (['contact_id','contract_id','membership_type_id','date'] as $parameter_name) {
+      $value = $parameters->getParameter($parameter_name);
+      if (!empty($value)) {
+        $contract_data[$parameter_name] = $value;
+      }
+    }
+    // add override fields to contract_data
+    foreach (['membership_type_id'] as $parameter_name) {
+      $value = $parameters->getParameter($parameter_name);
+      if (empty($value)) {
+        $value = $this->configuration->getParameter("default_{$parameter_name}");
+      }
+      $contract_data[$parameter_name] = $value;
+    }
+
+
+    // create mandate
+    try {
+      $contract = \civicrm_api3('Contract', 'modify', $contract_data);
+      $output->setParameter('contract_id', $contract['id']);
+    } catch (\Exception $ex) {
+      $output->setParameter('contract_id', '');
+      $output->setParameter('error', $ex->getMessage());
+    }
+  }
+
+  /**
+   * Get a list of all membership types
+   */
+  protected function getMembershipTypes() {
+    $creditor_list = [];
+    $creditor_query = \civicrm_api3('MembershipType', 'get', ['option.limit' => 0]);
+    foreach ($creditor_query['values'] as $creditor) {
+      $creditor_list[$creditor['id']] = $creditor['name'];
+    }
+    return $creditor_list;
+  }
+
+}

--- a/Civi/Contract/ActionProvider/Action/UpdateContract.php
+++ b/Civi/Contract/ActionProvider/Action/UpdateContract.php
@@ -32,14 +32,14 @@ class UpdateContract extends AbstractAction {
    */
   public function getConfigurationSpecification() {
     return new SpecificationBag([
-        new Specification('default_action',       'Integer', E::ts('Modify Action (default)'), true, null, null, $this->getModifyActions(), false),
-        new Specification('default_membership_type_id',       'Integer', E::ts('Membership Type ID (default)'), true, null, null, $this->getMembershipTypes(), false),
-        new Specification('default_creditor_id',       'Integer', E::ts('Creditor (default)'), true, null, null, $this->getCreditors(), false),
-        new Specification('default_financial_type_id', 'Integer', E::ts('Financial Type (default)'), true, null, null, $this->getFinancialTypes(), false),
-        new Specification('default_campaign_id',       'Integer', E::ts('Campaign (default)'), false, null, null, $this->getCampaigns(), false),
-        new Specification('default_frequency',         'Integer', E::ts('Frequency (default)'), true, 12, null, $this->getFrequencies()),
-        new Specification('default_cycle_day',         'Integer', E::ts('Collection Day (default)'), false, 0, null, $this->getCollectionDays()),
-        new Specification('buffer_days',               'Integer', E::ts('Buffer Days'), true, 7),
+        #new Specification('default_action',       'Integer', E::ts('Modify Action (default)'), true, null, null, $this->getModifyActions(), false),
+        #new Specification('default_membership_type_id',       'Integer', E::ts('Membership Type ID (default)'), true, null, null, $this->getMembershipTypes(), false),
+        #new Specification('default_creditor_id',       'Integer', E::ts('Creditor (default)'), true, null, null, $this->getCreditors(), false),
+        #new Specification('default_financial_type_id', 'Integer', E::ts('Financial Type (default)'), true, null, null, $this->getFinancialTypes(), false),
+        #new Specification('default_campaign_id',       'Integer', E::ts('Campaign (default)'), false, null, null, $this->getCampaigns(), false),
+        #new Specification('default_frequency',         'Integer', E::ts('Frequency (default)'), true, 12, null, $this->getFrequencies()),
+        #new Specification('default_cycle_day',         'Integer', E::ts('Collection Day (default)'), false, 0, null, $this->getCollectionDays()),
+        #new Specification('buffer_days',               'Integer', E::ts('Buffer Days'), true, 7),
 
     ]);
   }
@@ -52,7 +52,7 @@ class UpdateContract extends AbstractAction {
   public function getParameterSpecification() {
     return new SpecificationBag([
         // required fields
-        new Specification('contact_id', 'Integer', E::ts('Contact ID'), false),
+        #new Specification('contact_id', 'Integer', E::ts('Contact ID'), false),
         new Specification('contract_id', 'Integer', E::ts('Contract ID'), true),
         new Specification('membership_type_id',       'Integer', E::ts('Membership Type ID'), false),
 
@@ -69,9 +69,9 @@ class UpdateContract extends AbstractAction {
       campaign_id
         */
 
-        new Specification('iban',       'String',  E::ts('IBAN'), true),
-        new Specification('bic',        'String',  E::ts('BIC'), true),
-        new Specification('contract_updates.ch_annual',     'Money',   E::ts('Anual Amount'), true),
+        new Specification('iban',       'String',  E::ts('IBAN'), false),
+        new Specification('bic',        'String',  E::ts('BIC'), false),
+        new Specification('contract_updates.ch_annual',     'Money',   E::ts('Anual Amount'), false),
         new Specification('contract_updates.reference',  'String',  E::ts('Mandate Reference'), false),
 
         // recurring information
@@ -123,7 +123,7 @@ class UpdateContract extends AbstractAction {
    * @return void
    */
   protected function doAction(ParameterBagInterface $parameters, ParameterBagInterface $output) {
-    $contract_data = [];
+    $contract_data = ['action' => 'update'];
     // add basic fields to contract_data
     foreach (['contact_id','date','membership_type_id','contract_updates.ch_annual','contract_updates.reference','contract_updates.ch_frequency','contract_updates.ch_cycle_day'] as $parameter_name) {
       $value = $parameters->getParameter($parameter_name);
@@ -140,20 +140,8 @@ class UpdateContract extends AbstractAction {
       $contract_data[$parameter_name] = $value;
     }
 
-    // add basic fields to banking_data
-    $banking_data = [];
-    foreach (['contact_id','iban', 'bic'] as $parameter_name) {
-      $value = $parameters->getParameter($parameter_name);
-      if (!empty($value)) {
-        $banking_data[$parameter_name] = $value;
-      }
-    }
-
     try {
-      // Create Bank account if it does not exists
-      $bank_id = CRM_Contract_BankingLogic::getOrCreateBankAccount($banking_data['contact_id'],$banking_data['iban'],$banking_data['bic']);
-      // create mandate
-      $contract_data['contract_updates.ch_from_ba'] = $bank_id;
+      // update manadate
       $contract = \civicrm_api3('Contract', 'modify', $contract_data);
       $output->setParameter('contract_id', $contract['id']);
     } catch (\Exception $ex) {

--- a/Civi/Contract/ContainerSpecs.php
+++ b/Civi/Contract/ContainerSpecs.php
@@ -37,6 +37,9 @@ class ContainerSpecs implements CompilerPassInterface {
     $typeFactoryDefinition->addMethodCall('addAction', ['GetContract', 'Civi\Contract\ActionProvider\Action\GetContract', E::ts('Contract: Get'), [
         \Civi\ActionProvider\Action\AbstractAction::SINGLE_CONTACT_ACTION_TAG,
     ]]);
+    $typeFactoryDefinition->addMethodCall('addAction', ['GetSepaRcur', 'Civi\Contract\ActionProvider\Action\GetSepaRcur', E::ts('Contract: Get Sepa'), [
+        \Civi\ActionProvider\Action\AbstractAction::SINGLE_CONTACT_ACTION_TAG,
+    ]]);
     $typeFactoryDefinition->addMethodCall('addAction', ['PauseContract', 'Civi\Contract\ActionProvider\Action\PauseContract', E::ts('Contract: Pause'), [
         \Civi\ActionProvider\Action\AbstractAction::SINGLE_CONTACT_ACTION_TAG,
     ]]);

--- a/Civi/Contract/ContainerSpecs.php
+++ b/Civi/Contract/ContainerSpecs.php
@@ -34,6 +34,9 @@ class ContainerSpecs implements CompilerPassInterface {
     $typeFactoryDefinition->addMethodCall('addAction', ['CreateContract', 'Civi\Contract\ActionProvider\Action\CreateContract', E::ts('Contract: Create'), [
         \Civi\ActionProvider\Action\AbstractAction::SINGLE_CONTACT_ACTION_TAG,
     ]]);
+    $typeFactoryDefinition->addMethodCall('addAction', ['GetContract', 'Civi\Contract\ActionProvider\Action\GetContract', E::ts('Contract: Get'), [
+        \Civi\ActionProvider\Action\AbstractAction::SINGLE_CONTACT_ACTION_TAG,
+    ]]);
     $typeFactoryDefinition->addMethodCall('addAction', ['PauseContract', 'Civi\Contract\ActionProvider\Action\PauseContract', E::ts('Contract: Pause'), [
         \Civi\ActionProvider\Action\AbstractAction::SINGLE_CONTACT_ACTION_TAG,
     ]]);

--- a/Civi/Contract/ContainerSpecs.php
+++ b/Civi/Contract/ContainerSpecs.php
@@ -31,14 +31,24 @@ class ContainerSpecs implements CompilerPassInterface {
       return;
     }
     $typeFactoryDefinition = $container->getDefinition('action_provider');
-    $typeFactoryDefinition->addMethodCall('addAction', ['CreateContract', 'Civi\Contract\ActionProvider\Action\CreateContract', E::ts('Create Contract'), [
+    $typeFactoryDefinition->addMethodCall('addAction', ['CreateContract', 'Civi\Contract\ActionProvider\Action\CreateContract', E::ts('Contract: Create'), [
         \Civi\ActionProvider\Action\AbstractAction::SINGLE_CONTACT_ACTION_TAG,
     ]]);
-    /*$typeFactoryDefinition->addMethodCall('addAction', ['SepaMandateRCUR', 'Civi\Contract\ActionProvider\Action\CreateRecurringMandate', E::ts('Create SEPA Mandate (Recurring)'), [
+    $typeFactoryDefinition->addMethodCall('addAction', ['PauseContract', 'Civi\Contract\ActionProvider\Action\PauseContract', E::ts('Contract: Pause'), [
         \Civi\ActionProvider\Action\AbstractAction::SINGLE_CONTACT_ACTION_TAG,
     ]]);
-    $typeFactoryDefinition->addMethodCall('addAction', ['FindMandate', 'Civi\Contract\ActionProvider\Action\FindMandate', E::ts('Find SEPA Mandate'), [
-        \Civi\ActionProvider\Action\AbstractAction::DATA_RETRIEVAL_TAG,
-    ]]);*/
+    $typeFactoryDefinition->addMethodCall('addAction', ['ResumeContract', 'Civi\Contract\ActionProvider\Action\ResumeContract', E::ts('Contract: Resume'), [
+        \Civi\ActionProvider\Action\AbstractAction::SINGLE_CONTACT_ACTION_TAG,
+    ]]);
+    $typeFactoryDefinition->addMethodCall('addAction', ['CancelContract', 'Civi\Contract\ActionProvider\Action\CancelContract', E::ts('Contract: Cancel'), [
+        \Civi\ActionProvider\Action\AbstractAction::SINGLE_CONTACT_ACTION_TAG,
+    ]]);
+    $typeFactoryDefinition->addMethodCall('addAction', ['ReviveContract', 'Civi\Contract\ActionProvider\Action\ReviveContract', E::ts('Contract: Revive'), [
+        \Civi\ActionProvider\Action\AbstractAction::SINGLE_CONTACT_ACTION_TAG,
+    ]]);
+    $typeFactoryDefinition->addMethodCall('addAction', ['UpdateContract', 'Civi\Contract\ActionProvider\Action\UpdateContract', E::ts('Contract: Update'), [
+        \Civi\ActionProvider\Action\AbstractAction::SINGLE_CONTACT_ACTION_TAG,
+    ]]);
+
   }
 }

--- a/Civi/Contract/ContainerSpecs.php
+++ b/Civi/Contract/ContainerSpecs.php
@@ -1,0 +1,44 @@
+<?php
+/*-------------------------------------------------------+
+| Project 60 - SEPA direct debit                         |
+| Copyright (C) 2019 SYSTOPIA                            |
+| Author: B. Endres (endres -at- systopia.de)            |
+| http://www.systopia.de/                                |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++--------------------------------------------------------*/
+
+namespace Civi\Contract;
+
+use CRM_Contract_ExtensionUtil as E;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ContainerSpecs implements CompilerPassInterface {
+
+  /**
+   * Register SEPA Actions
+   */
+  public function process(ContainerBuilder $container) {
+    if (!$container->hasDefinition('action_provider')) {
+      return;
+    }
+    $typeFactoryDefinition = $container->getDefinition('action_provider');
+    $typeFactoryDefinition->addMethodCall('addAction', ['CreateContract', 'Civi\Contract\ActionProvider\Action\CreateContract', E::ts('Create Contract'), [
+        \Civi\ActionProvider\Action\AbstractAction::SINGLE_CONTACT_ACTION_TAG,
+    ]]);
+    /*$typeFactoryDefinition->addMethodCall('addAction', ['SepaMandateRCUR', 'Civi\Contract\ActionProvider\Action\CreateRecurringMandate', E::ts('Create SEPA Mandate (Recurring)'), [
+        \Civi\ActionProvider\Action\AbstractAction::SINGLE_CONTACT_ACTION_TAG,
+    ]]);
+    $typeFactoryDefinition->addMethodCall('addAction', ['FindMandate', 'Civi\Contract\ActionProvider\Action\FindMandate', E::ts('Find SEPA Mandate'), [
+        \Civi\ActionProvider\Action\AbstractAction::DATA_RETRIEVAL_TAG,
+    ]]);*/
+  }
+}

--- a/contract.php
+++ b/contract.php
@@ -10,7 +10,23 @@
 
 
 require_once 'contract.civix.php';
+require_once 'Civi/Contract/ContainerSpecs.php';
+require_once 'Civi/Contract/ActionProvider/Action/CreateContract.php';
 use CRM_Contract_ExtensionUtil as E;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Implements hook_civicrm_container()
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_container/
+ */
+function contract_civicrm_container(ContainerBuilder $container) {
+  #if (class_exists('\Civi\Contract\ContainerSpecs')) {
+      #$container->addCompilerPass(new Civi\Contract\ContainerSpecs());
+      $container->addCompilerPass(new \Civi\Contract\ContainerSpecs());
+  #}
+}
+
 
 /**
  * Implements hook_civicrm_config().
@@ -388,3 +404,4 @@ function contract_civicrm_entityTypes(&$entityTypes) {
       'table' => 'civicrm_contract_payment',
   );
 }
+

--- a/contract.php
+++ b/contract.php
@@ -10,8 +10,6 @@
 
 
 require_once 'contract.civix.php';
-require_once 'Civi/Contract/ContainerSpecs.php';
-require_once 'Civi/Contract/ActionProvider/Action/CreateContract.php';
 use CRM_Contract_ExtensionUtil as E;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -22,7 +20,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 function contract_civicrm_container(ContainerBuilder $container) {
   #if (class_exists('\Civi\Contract\ContainerSpecs')) {
-      #$container->addCompilerPass(new Civi\Contract\ContainerSpecs());
       $container->addCompilerPass(new \Civi\Contract\ContainerSpecs());
   #}
 }

--- a/contract.php
+++ b/contract.php
@@ -19,9 +19,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_container/
  */
 function contract_civicrm_container(ContainerBuilder $container) {
-  #if (class_exists('\Civi\Contract\ContainerSpecs')) {
+  if (class_exists('\Civi\Contract\ContainerSpecs')) {
       $container->addCompilerPass(new \Civi\Contract\ContainerSpecs());
-  #}
+  }
 }
 
 

--- a/info.xml
+++ b/info.xml
@@ -23,6 +23,7 @@
   <requires>
     <ext>org.project60.sepa</ext>
     <ext>org.project60.banking</ext>
+    <ext>action-provider</ext>
   </requires>
   <comments>Concept by B. Endres and M. Haefner, Greenpeace CEE. First implementation by Michael McAndrew, michaelmcandrew@thirdsectordesign.org</comments>
   <civix>

--- a/info.xml
+++ b/info.xml
@@ -23,9 +23,11 @@
   <requires>
     <ext>org.project60.sepa</ext>
     <ext>org.project60.banking</ext>
-    <ext>action-provider</ext>
   </requires>
   <comments>Concept by B. Endres and M. Haefner, Greenpeace CEE. First implementation by Michael McAndrew, michaelmcandrew@thirdsectordesign.org</comments>
+  <classloader>
+    <psr4 prefix="Civi\" path="Civi" />
+  </classloader>
   <civix>
     <namespace>CRM/Contract</namespace>
   </civix>


### PR DESCRIPTION
To be able to use the Contract Extension in Custom APIs these Formprocessor Actions are very usefull.