### PR TITLE
[#79] fixed activity title issues with changes including thousand separator

### DIFF
--- a/Civi/Contract/Event/RenderChangeSubjectEvent.php
+++ b/Civi/Contract/Event/RenderChangeSubjectEvent.php
@@ -268,8 +268,13 @@ class RenderChangeSubjectEvent extends ConfigurationEvent
     $value = $this->getChangeAttribute('contract_updates.ch_annual_diff');
     if (!$value) {
       // no diff recorded, try to calculate
-      $before = (float) $this->getContractDataBefore('membership_payment.membership_annual');
-      $after = (float) $this->getContractDataAfter('membership_payment.membership_annual');
+      $before = $this->getContractDataBefore('membership_payment.membership_annual');
+      $after = $this->getContractDataAfter('membership_payment.membership_annual');
+
+      // this value's formatted, make sure there's no thousand separator in the values
+      $thousand_separator = \CRM_Core_Config::singleton()->monetaryThousandSeparator;
+      $before = (float) preg_replace("/[{$thousand_separator}]/", '', $before);
+      $after = (float) preg_replace("/[{$thousand_separator}]/", '', $after);
       $value = $after - $before;
     }
     return (float) $value;

--- a/tests/phpunit/CRM/Contract/CompatibilityTest.php
+++ b/tests/phpunit/CRM/Contract/CompatibilityTest.php
@@ -50,10 +50,16 @@ class CRM_Contract_CompatibilityTest extends CRM_Contract_ContractTestBase
     $this->runContractEngine($contract['id'], '+2 days');
     $change_activity = $this->getLastChangeActivity($contract['id']);
     $this->assertNotEmpty($change_activity, "There should be a change activity after the upgrade");
-    $this->assertStringContainsOtherString("cycle day 25 to 3", $change_activity['subject'], "Activity subject should contain the changed cycle day");
-    $this->assertStringContainsOtherString("amt. 144.00 to 168.00", $change_activity['subject'], "Activity subject should contain the changed amount");
-    $this->assertStringNotContainsOtherString("DE89370400440532013000", $change_activity['subject'], "Activity subject should NOT contain the unchanged IBAN");
-    $this->assertStringNotContainsOtherString("freq. 12 to 12", $change_activity['subject'], "Activity subject should NOT contain the unchanged frequency");
+
+    if ($this->isExtensionActive('tazcontract')) {
+      $this->assertStringContainsOtherString("Anpassung", $change_activity['subject'], "Activity subject should contain 'Anpassung'");
+      $this->assertStringContainsOtherString("erhöht", $change_activity['subject'], "Activity subject should contain 'erhöht'");
+    } else {
+      $this->assertStringContainsOtherString("cycle day 25 to 3", $change_activity['subject'], "Activity subject should contain the changed cycle day");
+      $this->assertStringContainsOtherString("amt. 144.00 to 168.00", $change_activity['subject'], "Activity subject should contain the changed amount");
+      $this->assertStringNotContainsOtherString("DE89370400440532013000", $change_activity['subject'], "Activity subject should NOT contain the unchanged IBAN");
+      $this->assertStringNotContainsOtherString("freq. 12 to 12", $change_activity['subject'], "Activity subject should NOT contain the unchanged frequency");
+    }
   }
 
   /**

--- a/tests/phpunit/CRM/Contract/ContractTestBase.php
+++ b/tests/phpunit/CRM/Contract/ContractTestBase.php
@@ -37,7 +37,7 @@ class CRM_Contract_ContractTestBase extends TestCase implements HeadlessInterfac
         ->installMe(__DIR__)
         ->install('org.project60.sepa')
         ->install('org.project60.banking')
-        //->install('tazcontract')
+        //->install('tazcontract') // if changed, don't forget to 'DELETE FROM civitest_revs;' before running again
         ->apply();
   }
 
@@ -541,5 +541,16 @@ class CRM_Contract_ContractTestBase extends TestCase implements HeadlessInterfac
    */
   public function setActivityFlavour($type) {
     // TODO: this needs to be implemented when other flavours are available
+  }
+
+  /**
+   * Check if the given extension is installed
+   *
+   * @return bool
+   *   is the extension installed
+   */
+  public function isExtensionActive($extension_key) : bool
+  {
+    return function_exists("_{$extension_key}_civix_civicrm_enable");
   }
 }


### PR DESCRIPTION
Fixes garbled amount texts in records (activities) for large amounts.