### PR TITLE
Use Ajax snippet 2 for not printing when loading contract details in membership table

### DIFF
--- a/templates/CRM/Member/Page/Tab.js
+++ b/templates/CRM/Member/Page/Tab.js
@@ -27,7 +27,7 @@ CRM.$(function($) {
     // update/create the review link
     var link = $(document).find('#crm-membership-review-link_' + membershipId);
     if (link.length == 0) {
-      var queryURL = CRM.url('civicrm/contract/review', 'reset=&snippet=1&id=' + membershipId);
+      var queryURL = CRM.url('civicrm/contract/review', 'reset=&snippet=2&id=' + membershipId);
       link = " <a class='toggle-review' id='crm-membership-review-link_" + membershipId + "' href='" + queryURL + "'>[" + getReviewLinkText(membershipId) + "]</a>";
       $(this).after("<tr class='crm-membership crm-membership-review odd odd-row' id='crm-membership-review_" + membershipId + "'><td colspan='" + $(this).find('td').length + "'></td></tr>");
       $(this).find('td.crm-membership-status').append(link);
@@ -76,7 +76,7 @@ CRM.$(function($) {
       reviewRow.hide();
       reviewLink.html('[' + getReviewLinkText(membershipId) + ']');
     }else{
-      var queryURL = CRM.url('civicrm/contract/review', 'reset=&snippet=1&id=' + membershipId);
+      var queryURL = CRM.url('civicrm/contract/review', 'reset=&snippet=2&id=' + membershipId);
       reviewRow.find('table.contract-history-table').parent().remove(); // this seems to still stick around...
       reviewRow.find('td').load(queryURL, function(){
         reviewRow.show();
@@ -87,7 +87,7 @@ CRM.$(function($) {
 
   function updateReviewPane(membershipId){
     var reviewRow = $(document).find('#crm-membership-review_' + membershipId);
-    var queryURL = CRM.url('civicrm/contract/review', 'reset=&snippet=1&id=' + membershipId);
+    var queryURL = CRM.url('civicrm/contract/review', 'reset=&snippet=2&id=' + membershipId);
     reviewRow.find('td').load(queryURL);
   }
 


### PR DESCRIPTION
When loading details for a contract in the membership list on a contact, the browser's print dialog opens. This is due to the `snippet=1` query parameter, which tells CiviCRM to include the `print.tpl` template invoking `window.print()`

The correct Ajax snippet is `2` for not including CMS/CiviCRM assets for embedding Ajax-loaded content, see https://github.com/civicrm/civicrm-core/blob/f0a6e00f9aa30906848a23129fec1f46b4d2739b/CRM/Core/Smarty.php#L29-L46

*systopia-reference: 29190*