### PR TITLE
fix: creation of new SEPA Mandate based on the settings of payment method

### DIFF
--- a/CRM/Contract/Form/Create.php
+++ b/CRM/Contract/Form/Create.php
@@ -362,7 +362,7 @@ class CRM_Contract_Form_Create extends CRM_Core_Form {
     // SWITCH: contract creation/selection differs on the slected option
     switch ($submitted['payment_option']) {
       // CREATE NEW SEPA MANDATE
-      case '':
+      case 'RCUR':
         $payment_contract = CRM_Contract_SepaLogic::createNewMandate([
           'type'               => 'RCUR',
           'contact_id'         => $this->get('cid'),
@@ -377,7 +377,7 @@ class CRM_Contract_Form_Create extends CRM_Core_Form {
           'iban'               => $submitted['iban'],
           'bic'                => $submitted['bic'],
           'account_holder'     => $submitted['account_holder'],
-          'campaign_id'        => $submitted['campaign_id'],
+          'campaign_id'        => $submitted['campaign_id'] ?? NULL,
         // Membership Dues
           'financial_type_id'  => 2,
           'frequency_unit'     => 'month',

--- a/tests/phpunit/CRM/Contract/Form/CreateFormTest.php
+++ b/tests/phpunit/CRM/Contract/Form/CreateFormTest.php
@@ -302,15 +302,11 @@ class CreateFormTest extends ContractTestBase {
 
     self::assertEquals($this->contact['id'], $contract['contact_id']);
     self::assertEquals($this->membershipType['id'], $contract['membership_type_id']);
-    self::assertEquals(12, $contract['membership_payment.membership_frequency']);
     self::assertEquals('TEST-001', $contract['membership_general.membership_contract']);
     self::assertEquals('REF-001', $contract['membership_general.membership_reference']);
     if ($paymentOption == 'none') {
       self::assertEquals('0.00', $contract['membership_payment.membership_annual']);
 
-    }
-    elseif ($paymentOption == 'RCUR') {
-      self::assertEquals('1,440.00', $contract['membership_payment.membership_annual']);
     }
   }
 


### PR DESCRIPTION
creation of new SEPA Mandate based on the settings of payment method

*systopia-reference: 29565*