### PR TITLE
Fix option key to compare with for using existing payment contract in create contract form

### DIFF
--- a/CRM/Contract/Form/Create.php
+++ b/CRM/Contract/Form/Create.php
@@ -416,7 +416,7 @@ class CRM_Contract_Form_Create extends CRM_Core_Form {
         break;
 
       // SELECT EXISTING PAYMENT CONTRACT
-      case 'existing':
+      case 'select':
         $payment_contract['id'] = $submitted['recurring_contribution'];
         break;
 


### PR DESCRIPTION
There is not and has apparently never been an option with the key `existing` in the dropdown, so this `switch…case` doesn't seem right.

@bjendres can you have a look at that, because this has been that way from the beginning and maybe I'm missing something here …?