### PR TITLE
test(ModifyForm): resolve payment_instrument_id by name

### DIFF
--- a/CRM/Contract/Upgrader.php
+++ b/CRM/Contract/Upgrader.php
@@ -11,6 +11,8 @@
 declare(strict_types = 1);
 
 use CRM_Contract_ExtensionUtil as E;
+use Civi\Api4\OptionGroup;
+use Civi\Api4\OptionValue;
 
 /**
  * Collection of upgrade steps.
@@ -94,8 +96,8 @@ class CRM_Contract_Upgrader extends CRM_Extension_Upgrader_Base {
   public function upgrade_1403() {
     $this->ctx->log->info('Applying updates for 14xx');
     $customData = new CRM_Contract_CustomData(E::LONG_NAME);
-    $customData->syncOptionGroup(E::path('resources/custom_group_contract_updates.json'));
-    $customData->syncOptionGroup(E::path('resources/custom_group_membership_payment.json'));
+    $customData->syncOptionGroup(E::path('resources/option_group_contract_updates.json'));
+    $customData->syncOptionGroup(E::path('resources/option_group_membership_payment.json'));
     $this->ensureNoPaymentRequiredPaymentInstrument();
     return TRUE;
   }
@@ -167,43 +169,82 @@ class CRM_Contract_Upgrader extends CRM_Extension_Upgrader_Base {
 
   protected function ensureNoPaymentRequiredPaymentInstrument() {
     try {
-      $optionGroup = civicrm_api3('OptionGroup', 'getsingle', [
-        'name' => 'payment_instrument',
-      ]);
+      $og = OptionGroup::get(FALSE)
+        ->addWhere('name', '=', 'payment_instrument')
+        ->setSelect(['id'])
+        ->setLimit(1)
+        ->execute()
+        ->first();
     }
-    catch (Exception $e) {
+    catch (\Throwable $e) {
+      return;
+    }
+    if (!$og || empty($og['id'])) {
+      return;
+    }
+    $gid = (int) $og['id'];
+
+    $currentNone = OptionValue::get(FALSE)
+      ->addWhere('option_group_id', '=', $gid)
+      ->addWhere('name', '=', 'None')
+      ->setSelect(['id', 'value'])
+      ->setLimit(1)
+      ->execute()
+      ->first();
+
+    $legacy = OptionValue::get(FALSE)
+      ->addWhere('option_group_id', '=', $gid)
+      ->addWhere('name', '=', 'no_payment_required')
+      ->setSelect(['id', 'value'])
+      ->setLimit(1)
+      ->execute()
+      ->first();
+
+    if ($legacy && !$currentNone) {
+      OptionValue::update(FALSE)
+        ->addWhere('id', '=', $legacy['id'])
+        ->addValue('name', 'None')
+        ->addValue('label', 'No payment required')
+        ->execute()
+        ->single();
+      CRM_Core_PseudoConstant::flush();
       return;
     }
 
-    $existing = civicrm_api3('OptionValue', 'get', [
-      'option_group_id' => $optionGroup['id'],
-      'name' => 'None',
-      'return' => 'id',
-    ]);
-    if ($existing['count'] > 0) {
+    if ($legacy && $currentNone) {
+      OptionValue::delete(FALSE)
+        ->addWhere('id', '=', $legacy['id'])
+        ->execute();
+      CRM_Core_PseudoConstant::flush();
       return;
     }
 
-    civicrm_api3('OptionValue', 'create', [
-      'option_group_id' => $optionGroup['id'],
-      'label' => 'No payment required',
-      'name' => 'None',
-      'value' => $this->findNextAvailablePaymentInstrumentValue($optionGroup['id']),
-      'is_active' => 1,
-      'is_reserved' => 0,
-      'weight' => 99,
-    ]);
+    if (!$currentNone) {
+      OptionValue::create(FALSE)
+        ->addValue('option_group_id', $gid)
+        ->addValue('label', 'No payment required')
+        ->addValue('name', 'None')
+        ->addValue('value', $this->findNextAvailablePaymentInstrumentValue($gid))
+        ->addValue('is_active', 1)
+        ->addValue('is_reserved', 0)
+        ->addValue('weight', 99)
+        ->execute()
+        ->single();
+      CRM_Core_PseudoConstant::flush();
+    }
   }
 
   protected function findNextAvailablePaymentInstrumentValue($optionGroupId) {
-    $values = civicrm_api3('OptionValue', 'get', [
-      'option_group_id' => $optionGroupId,
-      'options' => ['limit' => 0],
-      'return' => ['value'],
-    ]);
-    $used = array_map('intval', array_column($values['values'], 'value'));
+    $rows = OptionValue::get(FALSE)
+      ->addWhere('option_group_id', '=', (int) $optionGroupId)
+      ->setSelect(['value'])
+      ->setLimit(0)
+      ->execute()
+      ->getArrayCopy();
+
+    $used = array_map('intval', array_column($rows, 'value'));
     $next = 1;
-    while (in_array($next, $used)) {
+    while (in_array($next, $used, TRUE)) {
       $next++;
     }
     return $next;


### PR DESCRIPTION
- Replace hardcode ids with dynamic lookups via getPaymentInstrumentIdByName for RCUR/Cash/None.
- Flush PseudoConstant cache and retry when the option may have been freshly created.
- Do not force payment_instrument_id on the "existing" path.
- Prevent "'X' is not a valid option for field payment_instrument_id" and make tests portable across DBs (local/Docker/CI)