### PR TITLE
Update call to deprecated Smarty::get_template_vars

### DIFF
--- a/CRM/Contract/BAO/ContractPaymentLink.php
+++ b/CRM/Contract/BAO/ContractPaymentLink.php
@@ -169,7 +169,7 @@ class CRM_Contract_BAO_ContractPaymentLink extends CRM_Contract_DAO_ContractPaym
    * @param $page
    */
   public static function injectLinks(&$page) {
-    $contribution_recur = $page->getTemplate()->get_template_vars('recur');
+    $contribution_recur = $page->getTemplate()->getTemplateVars('recur');
     if (!empty($contribution_recur['id'])) {
       // gather some data
       $contribution_recur_id = (int) $contribution_recur['id'];

--- a/CRM/Contract/FormUtils.php
+++ b/CRM/Contract/FormUtils.php
@@ -50,7 +50,7 @@ class CRM_Contract_FormUtils {
     $id = CRM_Contract_Utils::getCustomFieldId($name);
 
     // Get the custom data that was sent to the template
-    $details = $this->form->get_template_vars('viewCustomData');
+    $details = $this->form->getTemplateVars('viewCustomData');
 
     // We need to know the id for the row of the custom group table that
     // this custom data is stored in
@@ -101,7 +101,7 @@ class CRM_Contract_FormUtils {
       'getsingle',
       ['custom_group_id' => 'membership_payment', 'name' => 'membership_recurring_contribution']
     );
-    $details = $this->form->get_template_vars('viewCustomData');
+    $details = $this->form->getTemplateVars('viewCustomData');
     $customGroupTableId = key($details[$rcur_field['custom_group_id']]);
     $recContributionId =
       $details[$rcur_field['custom_group_id']][$customGroupTableId]['fields'][$rcur_field['id']]['field_value'];
@@ -148,7 +148,7 @@ class CRM_Contract_FormUtils {
       ['custom_group_id' => 'contract_updates', 'name' => 'ch_membership_type']
     );
     // Get the custom data that was sent to the template
-    $details = $this->form->get_template_vars('viewCustomData');
+    $details = $this->form->getTemplateVars('viewCustomData');
 
     // We need to know the id for the row of the custom group table that
     // this custom data is stored in


### PR DESCRIPTION
Replaces deprecated function name with the forward-compat equivalent.

Note: the new getTemplateVars function has been available since CiviCRM 5.70.