### PR TITLE
Replace `source_record_id` with entity reference custom field in contract activities

### DIFF
--- a/CRM/Contract/Change.php
+++ b/CRM/Contract/Change.php
@@ -17,16 +17,33 @@ use CRM_Contract_ExtensionUtil as E;
  *
  * This new 'Change' concept is the replacement for the CRM_Contract_ModificationActivity
  *  and the CRM_Contract_Handlers
+ *
+ * @phpstan-type changeT array{
+ *   activity_type_id: int|string,
+ *   activity_date_time?: string,
+ *   campaign_id?: int,
+ *   membership_type_id?: int,
+ *   "contract_activity.contract_id"?: int,
+ *   "membership_payment.cycle_day"?: int,
+ *   "membership_payment.defer_payment_start"?: int,
+ *   "membership_payment.from_name"?: string,
+ *   "membership_payment.from_ba"?: string,
+ *   "membership_payment.to_ba"?: string,
+ *   "membership_payment.membership_annual"?: float,
+ *   "membership_payment.membership_frequency"?: int,
+ *   "membership_payment.membership_recurring_contribution"?: int,
+ *   "membership_payment.payment_instrument"?: int,
+ *   "membership_cancellation.membership_cancel_reason"?: string,
+ *  }
  */
 // phpcs:disable Generic.NamingConventions.AbstractClassNamePrefix.Missing
 abstract class CRM_Contract_Change {
 // phpcs:enable
 
   /**
-   * @phpstan-var array<string, mixed>
-   * Data representing the data. Will mostly be the activity data
+   * @phpstan-var changeT
    */
-  protected ?array $data = NULL;
+  protected array $data;
 
   /**
    * @phpstan-var array<string, mixed>
@@ -87,9 +104,9 @@ abstract class CRM_Contract_Change {
   ];
 
   /**
-   * @phpstan-param array<string, mixed>|null $data
+   * @phpstan-param changeT $data
    */
-  protected function __construct(?array $data) {
+  protected function __construct(array $data) {
     $this->data = $data;
     // make sure activity_type_id is numeric
     $this->data['activity_type_id'] = $this->getActvityTypeID();
@@ -179,8 +196,17 @@ abstract class CRM_Contract_Change {
   /**
    * Get the contract ID
    */
-  public function getContractID() {
-    return (int) $this->data['source_record_id'];
+  public function getContractID(): ?int {
+    $contractReferenceFieldId = \Civi\Api4\CustomField::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('custom_group_id:name', '=', 'contract_activity')
+      ->addWhere('name', '=', 'contract_id')
+      ->execute()
+      ->single()['id'];
+    $contractId = $this->data['contract_activity.contract_id']
+      ?? $this->data['custom_' . $contractReferenceFieldId]
+      ?? NULL;
+    return NULL !== $contractId ? (int) $contractId : NULL;
   }
 
   /**
@@ -193,6 +219,7 @@ abstract class CRM_Contract_Change {
     // propagate derived fields
     foreach (CRM_Contract_Change::FIELD_MAPPING_CHANGE_CONTRACT as $contract_attribute => $change_attribute) {
       if (empty($this->data[$change_attribute])) {
+        // @phpstan-ignore assign.propertyType
         $this->data[$change_attribute] = $contract[$contract_attribute] ?? '';
       }
     }
@@ -301,8 +328,8 @@ abstract class CRM_Contract_Change {
    * @return int activity type ID
    */
   public function getActvityTypeID() {
-    if (is_numeric($this->data['activity_type_id'])) {
-      return $this->data['activity_type_id'];
+    if (is_numeric($this->data['activity_type_id'] ?? NULL)) {
+      return (int) $this->data['activity_type_id'];
     }
 
     // otherwise translate class to ID
@@ -412,8 +439,8 @@ abstract class CRM_Contract_Change {
    * @param $value string value to set
    */
   public function setParameter($key, $value) {
+    // @phpstan-ignore assign.propertyType
     $this->data[$key] = $value;
-    // TODO: mark as dirty?
   }
 
   /**
@@ -674,24 +701,23 @@ abstract class CRM_Contract_Change {
   /**
    * Get the class for the given activity type
    *
-   * @param $activity_type int|string acitivity type ID or name
-   * @return string class name
+   * @param int|string $activity_type acitivity type ID or name
    */
-  public static function getClassByActivityType($activity_type_id) {
+  public static function getClassByActivityType($activity_type): ?string {
     // check name -> class mapping first
-    if (isset(self::TYPE2CLASS[$activity_type_id])) {
-      return self::TYPE2CLASS[$activity_type_id];
+    if (isset(self::TYPE2CLASS[$activity_type])) {
+      return self::TYPE2CLASS[$activity_type];
     }
 
     // check action -> class mapping second
-    if (isset(self::ACTION2CLASS[$activity_type_id])) {
-      return self::ACTION2CLASS[$activity_type_id];
+    if (isset(self::ACTION2CLASS[$activity_type])) {
+      return self::ACTION2CLASS[$activity_type];
     }
 
     // then try ID -> class
     $type_id2class = self::getActivityTypeId2Class();
-    if (isset($type_id2class[$activity_type_id])) {
-      return $type_id2class[$activity_type_id];
+    if (isset($type_id2class[$activity_type])) {
+      return $type_id2class[$activity_type];
     }
 
     // not found? not one of ours!
@@ -802,17 +828,18 @@ abstract class CRM_Contract_Change {
   /**
    * Get a change with data
    *
-   * @param $data array data
-   * @return CRM_Contract_Change change entity
-   * @throws Exception if the change type couldn't be detected from the activity_type_id
+   * @param changeT $data
+   * @return \CRM_Contract_Change change entity
+   * @throws \RuntimeException if the change type couldn't be detected from the activity_type_id
    */
   public static function getChangeForData($data) {
     if (empty($data['activity_type_id'])) {
       throw new \RuntimeException('No activity_type_id given.');
     }
 
+    /** @var class-string<\CRM_Contract_Change>|null $change_class */
     $change_class = self::getClassByActivityType($data['activity_type_id']);
-    if (empty($change_class)) {
+    if (NULL === $change_class) {
       throw new \RuntimeException(
         "Activity type ID '{$data['activity_type_id']}' is not a valid contract change type."
       );
@@ -828,15 +855,13 @@ abstract class CRM_Contract_Change {
   /**
    * Get a comma separated list of all change activity custom fields
    *
-   * @return string list of field names
+   * @phpstan-return list<string>
+   *   list of field names
    */
   public static function getCustomFieldList() {
     $field_names = [];
     $fields = CRM_Contract_CustomData::getCustomFieldsForGroups(['contract_cancellation', 'contract_updates']);
-    foreach ($fields as $field) {
-      $field_names[] = "custom_{$field['id']}";
-    }
-    return implode(',', $field_names);
+    return array_column($fields, 'name');
   }
 
   /**

--- a/CRM/Contract/Change.php
+++ b/CRM/Contract/Change.php
@@ -197,15 +197,19 @@ abstract class CRM_Contract_Change {
    * Get the contract ID
    */
   public function getContractID(): ?int {
-    $contractReferenceFieldId = \Civi\Api4\CustomField::get(FALSE)
-      ->addSelect('id')
-      ->addWhere('custom_group_id:name', '=', 'contract_activity')
-      ->addWhere('name', '=', 'contract_id')
-      ->execute()
-      ->single()['id'];
-    $contractId = $this->data['contract_activity.contract_id']
-      ?? $this->data['custom_' . $contractReferenceFieldId]
-      ?? NULL;
+    if (isset($this->data['contract_activity.contract_id'])) {
+      $contractId = $this->data['contract_activity.contract_id'];
+    }
+    else {
+      // Lookup for APIv3 custom field name.
+      $contractReferenceFieldId = \Civi\Api4\CustomField::get(FALSE)
+        ->addSelect('id')
+        ->addWhere('custom_group_id:name', '=', 'contract_activity')
+        ->addWhere('name', '=', 'contract_id')
+        ->execute()
+        ->single()['id'];
+      $contractId = $this->data['custom_' . $contractReferenceFieldId] ?? NULL;
+    }
     return NULL !== $contractId ? (int) $contractId : NULL;
   }
 
@@ -701,7 +705,8 @@ abstract class CRM_Contract_Change {
   /**
    * Get the class for the given activity type
    *
-   * @param int|string $activity_type acitivity type ID or name
+   * @param int|string $activity_type
+   *   Acitivity type ID, name, or change action name.
    */
   public static function getClassByActivityType($activity_type): ?string {
     // check name -> class mapping first

--- a/CRM/Contract/Change/Cancel.php
+++ b/CRM/Contract/Change/Cancel.php
@@ -156,12 +156,6 @@ class CRM_Contract_Change_Cancel extends CRM_Contract_Change {
     if ($this->isNew()) {
       return E::ts('Contract cancellation scheduled');
     }
-    if (isset($this->data['contract_cancellation.contact_history_cancel_reason'])) {
-      $reason = $this->labelValue(
-        $this->data['contract_cancellation.contact_history_cancel_reason'],
-        'contract_cancellation.contact_history_cancel_reason'
-      );
-    }
 
     return isset($this->data['contract_cancellation.contact_history_cancel_reason'])
       ? E::ts(

--- a/CRM/Contract/Change/Cancel.php
+++ b/CRM/Contract/Change/Cancel.php
@@ -60,6 +60,7 @@ class CRM_Contract_Change_Cancel extends CRM_Contract_Change {
     // cancel the contract by setting the end date
     $contract_update = [
       'end_date'                     => date('YmdHis'),
+      // @phpstan-ignore offsetAccess.notFound
       self::MEMBERSHIP_CANCEL_REASON => $this->data[self::MEMBERSHIP_CANCEL_REASON],
       self::MEMBERSHIP_CANCEL_DATE   => date('YmdHis'),
       'status_id'                    => 'Cancelled',
@@ -70,8 +71,10 @@ class CRM_Contract_Change_Cancel extends CRM_Contract_Change {
 
     // also: cancel the mandate/recurring contribution
     CRM_Contract_SepaLogic::terminateSepaMandate(
-        $contract['membership_payment.membership_recurring_contribution'],
-        $this->data[self::MEMBERSHIP_CANCEL_REASON]);
+      $contract['membership_payment.membership_recurring_contribution'],
+      // @phpstan-ignore offsetAccess.notFound
+      $this->data[self::MEMBERSHIP_CANCEL_REASON]
+    );
 
     // update change activity
     $contract_after = $this->getContract();
@@ -92,20 +95,29 @@ class CRM_Contract_Change_Cancel extends CRM_Contract_Change {
 
     // check for OTHER CANCELLATION REQUEST for the same day
     //  @see https://redmine.greenpeace.at/issues/1190
-    $requested_day = date('Y-m-d', strtotime($this->data['activity_date_time']));
-    $scheduled_activities = civicrm_api3('Activity', 'get', [
-      'source_record_id' => $this->getContractID(),
-      'activity_type_id' => $this->getActvityTypeID(),
-      'status_id'        => 'Scheduled',
-      'option.limit'     => 0,
-      'sequential'       => 1,
-      'return'           => 'id,activity_date_time',
-    ]);
-    foreach ($scheduled_activities['values'] as $scheduled_activity) {
-      $scheduled_for_day = date('Y-m-d', strtotime($scheduled_activity['activity_date_time']));
+    // @phpstan-ignore offsetAccess.notFound
+    $activityDateTime = strtotime($this->data['activity_date_time']);
+    if (FALSE === $activityDateTime) {
+      throw new \RuntimeException('Invalid activity date.');
+    }
+    $requested_day = date('Y-m-d', $activityDateTime);
+    /** @phpstan-var list<array{id: int, activity_date_time: string}> $scheduled_activities */
+    $scheduled_activities = \Civi\Api4\Activity::get(FALSE)
+      ->addSelect('id', 'activity_date_time')
+      ->addWhere('contract_activity.contract_id', '=', $this->getContractID())
+      ->addWhere('activity_type_id', '=', $this->getActvityTypeID())
+      ->addWhere('status_id:name', '=', 'Scheduled')
+      ->execute()
+      ->getArrayCopy();
+    foreach ($scheduled_activities as $scheduled_activity) {
+      $scheduledActivityDateTime = strtotime($scheduled_activity['activity_date_time']);
+      if (FALSE === $scheduledActivityDateTime) {
+        throw new \RuntimeException('Invalid activity date.');
+      }
+      $scheduled_for_day = date('Y-m-d', $scheduledActivityDateTime);
       if ($scheduled_for_day === $requested_day) {
-        // there's already a scheduled 'cancel' activity for the same day
-        throw new \RuntimeException('Scheduling an (additional) cancellation request in not desired in this context.');
+        // There is already a scheduled 'cancel' activity for the same day.
+        throw new \RuntimeException('Scheduling an (additional) cancellation request is not desired in this context.');
       }
     }
 
@@ -114,19 +126,21 @@ class CRM_Contract_Change_Cancel extends CRM_Contract_Change {
     //  @see https://redmine.greenpeace.at/issues/1190
     $contract = $this->getContract();
 
-    $contract_cancelled_status = civicrm_api3('MembershipStatus', 'get', [
+    /** @phpstan-var array{id: int} $contractCancelledStatus */
+    $contractCancelledStatus = civicrm_api3('MembershipStatus', 'get', [
       'name'   => 'Cancelled',
       'return' => 'id',
     ]);
-    if ((int) $contract['status_id'] == $contract_cancelled_status['id']) {
-      // contract is cancelled
-      $pending_activity_count = civicrm_api3('Activity', 'getcount', [
-        'source_record_id' => $this->getContractID(),
-        'activity_type_id' => ['IN' => CRM_Contract_Change::getActivityTypeIds()],
-        'status_id'        => ['IN' => ['Scheduled', 'Needs Review']],
-      ]);
-      if (0 === $pending_activity_count) {
-        throw new \RuntimeException('Scheduling an (additional) cancellation request in not desired in this context.');
+    if ((int) $contract['status_id'] === (int) $contractCancelledStatus['id']) {
+      $pendingActivityCount = \Civi\Api4\Activity::get(FALSE)
+        ->selectRowCount()
+        ->addWhere('contract_activity.contract_id', '=', $this->getContractID())
+        ->addWhere('activity_type_id', 'IN', CRM_Contract_Change::getActivityTypeIds())
+        ->addWhere('status_id:name', 'IN', ['Scheduled', 'Needs Review'])
+        ->execute()
+        ->count();
+      if (0 === $pendingActivityCount) {
+        throw new \RuntimeException('Scheduling an (additional) cancellation request is not desired in this context.');
       }
     }
   }
@@ -142,11 +156,24 @@ class CRM_Contract_Change_Cancel extends CRM_Contract_Change {
     if ($this->isNew()) {
       return E::ts('Contract cancellation scheduled');
     }
-    $reasonVal = $this->data['contract_cancellation.contact_history_cancel_reason'] ?? NULL;
-    $reason = NULL !== $reasonVal
-      ? $this->labelValue($reasonVal, 'contract_cancellation.contact_history_cancel_reason')
-      : NULL;
-    return $reason ? E::ts('Contract cancelled (%1)', [1 => $reason]) : E::ts('Contract cancelled');
+    if (isset($this->data['contract_cancellation.contact_history_cancel_reason'])) {
+      $reason = $this->labelValue(
+        $this->data['contract_cancellation.contact_history_cancel_reason'],
+        'contract_cancellation.contact_history_cancel_reason'
+      );
+    }
+
+    return isset($this->data['contract_cancellation.contact_history_cancel_reason'])
+      ? E::ts(
+        'Contract cancelled (%1)',
+        [
+          1 => $this->labelValue(
+            $this->data['contract_cancellation.contact_history_cancel_reason'],
+            'contract_cancellation.contact_history_cancel_reason'
+          ),
+        ]
+      )
+      : E::ts('Contract cancelled');
   }
 
   /**

--- a/CRM/Contract/Change/Cancel.php
+++ b/CRM/Contract/Change/Cancel.php
@@ -104,16 +104,15 @@ class CRM_Contract_Change_Cancel extends CRM_Contract_Change {
     /** @phpstan-var list<array{id: int, activity_date_time: string}> $scheduled_activities */
     $scheduled_activities = \Civi\Api4\Activity::get(FALSE)
       ->addSelect('id', 'activity_date_time')
+      ->addWhere('activity_date_time', 'IS NOT NULL')
       ->addWhere('contract_activity.contract_id', '=', $this->getContractID())
       ->addWhere('activity_type_id', '=', $this->getActvityTypeID())
       ->addWhere('status_id:name', '=', 'Scheduled')
       ->execute()
       ->getArrayCopy();
     foreach ($scheduled_activities as $scheduled_activity) {
+      /** @var int $scheduledActivityDateTime */
       $scheduledActivityDateTime = strtotime($scheduled_activity['activity_date_time']);
-      if (FALSE === $scheduledActivityDateTime) {
-        throw new \RuntimeException('Invalid activity date.');
-      }
       $scheduled_for_day = date('Y-m-d', $scheduledActivityDateTime);
       if ($scheduled_for_day === $requested_day) {
         // There is already a scheduled 'cancel' activity for the same day.

--- a/CRM/Contract/Change/Pause.php
+++ b/CRM/Contract/Change/Pause.php
@@ -61,7 +61,7 @@ class CRM_Contract_Change_Pause extends CRM_Contract_Change {
         $contract = $this->getContract();
         $resume_change = CRM_Contract_Change::getChangeForData(['activity_type_id' => 'Contract_Resumed']);
         $resume_change->setParameter('activity_date_time', $resume_date);
-        $resume_change->setParameter('source_record_id', $this->getContractID());
+        $resume_change->setParameter('contract_activity.contract_id', $this->getContractID());
         $resume_change->setParameter('source_contact_id', $this->getParameter('source_contact_id'));
         $resume_change->setParameter('target_contact_id', $contract['contact_id']);
         $resume_change->setParameter('subject', $resume_change->getSubject($contract));

--- a/CRM/Contract/Change/Pause.php
+++ b/CRM/Contract/Change/Pause.php
@@ -62,6 +62,7 @@ class CRM_Contract_Change_Pause extends CRM_Contract_Change {
         $resume_change = CRM_Contract_Change::getChangeForData(['activity_type_id' => 'Contract_Resumed']);
         $resume_change->setParameter('activity_date_time', $resume_date);
         $resume_change->setParameter('contract_activity.contract_id', $this->getContractID());
+        $resume_change->setParameter('source_record_id', $this->getContractID());
         $resume_change->setParameter('source_contact_id', $this->getParameter('source_contact_id'));
         $resume_change->setParameter('target_contact_id', $contract['contact_id']);
         $resume_change->setParameter('subject', $resume_change->getSubject($contract));

--- a/CRM/Contract/Change/Sign.php
+++ b/CRM/Contract/Change/Sign.php
@@ -95,7 +95,7 @@ class CRM_Contract_Change_Sign extends CRM_Contract_Change {
     if (!empty($c['membership_payment.cycle_day'])) {
       $parts[] = E::ts('Cycle day %1', [1 => $c['membership_payment.cycle_day']]);
     }
-    $suffix = $parts ? (' — ' . implode(' • ', $parts)) : '';
+    $suffix = [] !== $parts ? (' — ' . implode(' • ', $parts)) : '';
     return E::ts('New membership contract') . $suffix;
   }
 

--- a/CRM/Contract/Change/Upgrade.php
+++ b/CRM/Contract/Change/Upgrade.php
@@ -35,6 +35,7 @@ class CRM_Contract_Change_Upgrade extends CRM_Contract_Change {
       // copy submitted changes to change activity
       foreach (CRM_Contract_Change::FIELD_MAPPING_CHANGE_CONTRACT as $contract_attribute => $change_attribute) {
         if (!empty($this->data[$contract_attribute])) {
+          // @phpstan-ignore assign.propertyType
           $this->data[$change_attribute] = $this->data[$contract_attribute];
           $contract_after_execution[$contract_attribute] = $this->data[$contract_attribute];
         }

--- a/CRM/Contract/Handler/ModificationConflicts.php
+++ b/CRM/Contract/Handler/ModificationConflicts.php
@@ -14,9 +14,16 @@ declare(strict_types = 1);
 
 class CRM_Contract_Handler_ModificationConflicts {
 
-  private $scheduledModifications = [];
-  private $contractId = NULL;
-  protected $needsReviewStatusId;
+  /**
+   * @phpstan-var list<array{
+   *     id: int,
+   *     status_id: int|string,
+   *     activity_type_id: int,
+   *   }> $scheduledModifications
+   */
+  private array $scheduledModifications = [];
+  private ?int $contractId = NULL;
+  protected int $needsReviewStatusId;
 
   public function __construct() {
     $this->needsReviewStatusId = (int) civicrm_api3(
@@ -41,7 +48,7 @@ class CRM_Contract_Handler_ModificationConflicts {
     // consider to be safe. Any modifications left once all the functions have
     // been run will be marked for review.
 
-    $this->getScheduledModifications();
+    $this->retrieveScheduledModifications();
 
     $this->whitelistOneActivity();
 
@@ -56,21 +63,16 @@ class CRM_Contract_Handler_ModificationConflicts {
     }
   }
 
-  public function getScheduledModifications() {
-    $scheduledModifications = civicrm_api3('activity', 'get', [
-    // With more than 10,000 scheduled updates for this contract, probably time to review organisational procedures.
-      'option.limit' => 10000,
-      'source_record_id' => $this->contractId,
-      'status_id' => ['IN' => ['scheduled', 'needs review']],
-    ])['values'];
-    foreach ($scheduledModifications as $k => &$scheduledModification) {
-      $scheduledModification['activity_date_unixtime'] = strtotime($scheduledModification['activity_date_time']);
-    }
-    usort($scheduledModifications, function($a, $b) {
-      return $a['activity_date_unixtime'] - $b['activity_date_unixtime'];
-    });
-    $this->scheduledModifications = $scheduledModifications;
-
+  public function retrieveScheduledModifications(): void {
+    // TODO: This query used to have a limit of 10.000 but without ordering or other handling;
+    //       add performance-related error handling.
+    // @phpstan-ignore assign.propertyType
+    $this->scheduledModifications = \Civi\Api4\Activity::get(FALSE)
+      ->addWhere('contract_activity.contract_id', '=', $this->contractId)
+      ->addWhere('status_id:name', 'IN', ['Scheduled', 'Needs Review'])
+      ->addOrderBy('activity_date_time')
+      ->execute()
+      ->getArrayCopy();
   }
 
   /**
@@ -123,6 +125,7 @@ class CRM_Contract_Handler_ModificationConflicts {
       (int) $pauseActivity['activity_type_id'] === CRM_Contract_Change::getActivityIdForClass(
         'CRM_Contract_Change_Pause'
       )
+      && FALSE !== $resumeActivity
       && (int) $resumeActivity['activity_type_id'] === CRM_Contract_Change::getActivityIdForClass(
         'CRM_Contract_Change_Resume'
       )

--- a/CRM/Contract/Handler/ModificationConflicts.php
+++ b/CRM/Contract/Handler/ModificationConflicts.php
@@ -17,7 +17,7 @@ class CRM_Contract_Handler_ModificationConflicts {
   /**
    * @phpstan-var list<array{
    *     id: int,
-   *     status_id: int|string,
+   *     status_id: int,
    *     activity_type_id: int,
    *   }> $scheduledModifications
    */

--- a/CRM/Contract/Page/Review.php
+++ b/CRM/Contract/Page/Review.php
@@ -34,12 +34,9 @@ class CRM_Contract_Page_Review extends CRM_Core_Page {
       'return' => 'currency',
     ]));
 
-    // Set activity params
-    $activityParams = [
-      'source_record_id' => $id,
-      'status_id' => ['NOT IN' => ['cancelled']],
-      'activity_type_id' => ['IN' => CRM_Contract_Change::getActivityTypeIds()],
-      'return' => [
+    /** @phpstan-var array<int, array<string, mixed>> $activities */
+    $activities = \Civi\Api4\Activity::get(FALSE)
+      ->addSelect(
         'activity_date_time',
         'status_id',
         'activity_type_id',
@@ -48,25 +45,17 @@ class CRM_Contract_Page_Review extends CRM_Core_Page {
         'details',
         'campaign_id',
         'medium_id',
-      ],
-      'option.sort'        => 'activity_date_time DESC, id DESC',
-
-    ];
-    foreach (civicrm_api3(
-      'CustomField',
-      'get',
-      [
-        'custom_group_id' => [
-          'IN' => [
-            'contract_cancellation',
-            'contract_updates',
-          ],
-        ],
-      ]
-    )['values'] as $customField) {
-      $activityParams['return'][] = 'custom_' . $customField['id'];
-    }
-    $activities = civicrm_api3('Activity', 'get', $activityParams)['values'];
+        'contract_cancellation.*',
+        'contract_updates.*',
+      )
+      ->addWhere('contract_activity.contract_id', '=', $id)
+      ->addWhere('status_id', 'NOT IN', ['Cancelled'])
+      ->addWhere('activity_type_id', 'IN', CRM_Contract_Change::getActivityTypeIds())
+      ->addOrderBy('activity_date_time', 'DESC')
+      ->addOrderBy('id', 'DESC')
+      ->execute()
+      ->indexBy('id')
+      ->getArrayCopy();
 
     // Friendlify custom field names
     CRM_Contract_Utils::warmCustomFieldCache();
@@ -79,54 +68,55 @@ class CRM_Contract_Page_Review extends CRM_Core_Page {
     $cancelReasons = [];
 
     // todo: refactor for better performance
-    foreach ($activities as $key => $activity) {
-
-      foreach ($activity as $innerKey => $field) {
-        if (isset($customFieldIndex[$innerKey])) {
-          unset($activities[$key][$innerKey]);
-          $activities[$key][$customFieldIndex[$innerKey]] = $field;
+    foreach ($activities as $activityId => $activity) {
+      foreach ($activity as $fieldName => $field) {
+        $newFieldName = str_replace('.', '_', $fieldName);
+        if ($newFieldName !== $fieldName) {
+          unset($activities[$activityId][$fieldName]);
+          $activities[$activityId][$newFieldName] = $field;
         }
       }
       if (
-        isset($activities[$key]['contract_updates_ch_recurring_contribution'])
-        && $activities[$key]['contract_updates_ch_recurring_contribution']
+        isset($activities[$activityId]['contract_updates_ch_recurring_contribution'])
+        && $activities[$activityId]['contract_updates_ch_recurring_contribution']
       ) {
+        /** @phpstan-var array<string, mixed> $rc */
         $rc = civicrm_api3(
           'ContributionRecur',
           'getsingle',
-          ['id' => $activities[$key]['contract_updates_ch_recurring_contribution']]
+          ['id' => $activities[$activityId]['contract_updates_ch_recurring_contribution']]
         );
-        $activities[$key]['payment_instrument_id'] = $rc['payment_instrument_id'];
-        $activities[$key]['recurring_contribution_contact_id'] = $rc['contact_id'];
+        $activities[$activityId]['payment_instrument_id'] = $rc['payment_instrument_id'];
+        $activities[$activityId]['recurring_contribution_contact_id'] = $rc['contact_id'];
       }
       if (
-        isset($activities[$key]['contract_updates_ch_annual'])
-        && isset($activities[$key]['contract_updates_ch_frequency'])
-        && $activities[$key]['contract_updates_ch_annual']
-        && $activities[$key]['contract_updates_ch_frequency']
+        isset($activities[$activityId]['contract_updates_ch_annual'])
+        && isset($activities[$activityId]['contract_updates_ch_frequency'])
+        && $activities[$activityId]['contract_updates_ch_annual']
+        && $activities[$activityId]['contract_updates_ch_frequency']
       ) {
-        $activities[$key]['contract_updates_ch_amount'] = CRM_Contract_SepaLogic::formatMoney(
-            $activities[$key]['contract_updates_ch_annual']
-          ) / $activities[$key]['contract_updates_ch_frequency'];
-        $activities[$key]['contract_updates_ch_amount'] = CRM_Contract_SepaLogic::formatMoney(
-          $activities[$key]['contract_updates_ch_amount']
+        $activities[$activityId]['contract_updates_ch_amount'] = CRM_Contract_SepaLogic::formatMoney(
+            $activities[$activityId]['contract_updates_ch_annual']
+          ) / $activities[$activityId]['contract_updates_ch_frequency'];
+        $activities[$activityId]['contract_updates_ch_amount'] = CRM_Contract_SepaLogic::formatMoney(
+          $activities[$activityId]['contract_updates_ch_amount']
         );
       }
-      if (isset($activities[$key]['campaign_id'])) {
-        $campaigns[] = $activities[$key]['campaign_id'];
+      if (isset($activities[$activityId]['campaign_id'])) {
+        $campaigns[] = $activities[$activityId]['campaign_id'];
       }
-      if (isset($activities[$key]['contract_cancellation_contact_history_cancel_reason'])) {
-        $cancelReasons[] = $activities[$key]['contract_cancellation_contact_history_cancel_reason'];
+      if (isset($activities[$activityId]['contract_cancellation_contact_history_cancel_reason'])) {
+        $cancelReasons[] = $activities[$activityId]['contract_cancellation_contact_history_cancel_reason'];
       }
-      if (isset($activities[$key]['source_contact_id'])) {
-        $contacts[] = $activities[$key]['source_contact_id'];
+      if (isset($activities[$activityId]['source_contact_id'])) {
+        $contacts[] = $activities[$activityId]['source_contact_id'];
       }
 
       // add title/hover title
       $display_titles = DisplayChangeTitle::renderDisplayChangeTitleAndHoverText(
-                            $activities[$key]['activity_type_id'], $activities[$key]['id']);
-      $activities[$key]['display_title'] = $display_titles->getDisplayTitle();
-      $activities[$key]['display_hover_title'] = $display_titles->getDisplayHover();
+                            $activities[$activityId]['activity_type_id'], $activities[$activityId]['id']);
+      $activities[$activityId]['display_title'] = $display_titles->getDisplayTitle();
+      $activities[$activityId]['display_hover_title'] = $display_titles->getDisplayHover();
     }
 
     $this->assign('activities', $activities);
@@ -215,20 +205,6 @@ class CRM_Contract_Page_Review extends CRM_Core_Page {
     // since Civi 4.7, wysiwyg/ckeditor is a default core resource
     if (version_compare(CRM_Utils_System::version(), '4.7', '<')) {
       CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'packages/ckeditor/ckeditor.js');
-    }
-    foreach (civicrm_api3(
-      'CustomField',
-      'get',
-      [
-        'custom_group_id' => [
-          'IN' => [
-            'contract_cancellation',
-            'contract_updates',
-          ],
-        ],
-      ]
-    )['values'] as $customField) {
-      $activityParams['return'][] = 'custom_' . $customField['id'];
     }
 
     // hide some columns

--- a/CRM/Contract/Page/Review.php
+++ b/CRM/Contract/Page/Review.php
@@ -49,7 +49,7 @@ class CRM_Contract_Page_Review extends CRM_Core_Page {
         'contract_updates.*',
       )
       ->addWhere('contract_activity.contract_id', '=', $id)
-      ->addWhere('status_id', 'NOT IN', ['Cancelled'])
+      ->addWhere('status_id:name', 'NOT IN', ['Cancelled'])
       ->addWhere('activity_type_id', 'IN', CRM_Contract_Change::getActivityTypeIds())
       ->addOrderBy('activity_date_time', 'DESC')
       ->addOrderBy('id', 'DESC')

--- a/CRM/Contract/RecurringContribution.php
+++ b/CRM/Contract/RecurringContribution.php
@@ -205,6 +205,7 @@ class CRM_Contract_RecurringContribution {
       }
       $mandateReference = '';
       if (is_array($mandate) && isset($mandate['reference'])) {
+        /** @var string $mandateReference */
         $mandateReference = $mandate['reference'];
       }
 

--- a/CRM/Contract/SepaLogic.php
+++ b/CRM/Contract/SepaLogic.php
@@ -739,10 +739,11 @@ class CRM_Contract_SepaLogic {
   /**
    * Validate the given IBAN
    *
-   * @return TRUE if IBAN is valid
+   * @return bool
+   *   TRUE if IBAN is valid
    */
-  public static function validateIBAN($iban) {
-    return NULL == CRM_Sepa_Logic_Verification::verifyIBAN($iban);
+  public static function validateIBAN($iban): bool {
+    return NULL === CRM_Sepa_Logic_Verification::verifyIBAN($iban);
   }
 
   /**
@@ -760,7 +761,7 @@ class CRM_Contract_SepaLogic {
    * @return TRUE if BIC is valid
    */
   public static function validateBIC($bic) {
-    return NULL == CRM_Sepa_Logic_Verification::verifyBIC($bic);
+    return NULL === CRM_Sepa_Logic_Verification::verifyBIC($bic);
   }
 
   /**

--- a/CRM/Contract/Upgrader.php
+++ b/CRM/Contract/Upgrader.php
@@ -18,7 +18,7 @@ use Civi\Api4\OptionValue;
  */
 class CRM_Contract_Upgrader extends CRM_Extension_Upgrader_Base {
 
-  public function enable() {
+  public function enable(): void {
     require_once 'CRM/Contract/CustomData.php';
     $customData = new CRM_Contract_CustomData(E::LONG_NAME);
     $customData->syncOptionGroup(E::path('resources/option_group_contact_channel.json'));
@@ -42,7 +42,7 @@ class CRM_Contract_Upgrader extends CRM_Extension_Upgrader_Base {
    *
    * @return TRUE on success
    */
-  public function upgrade_1360() {
+  public function upgrade_1360(): bool {
     $this->ctx->log->info('Applying update 1360');
     $customData = new CRM_Contract_CustomData(E::LONG_NAME);
     $customData->syncCustomGroup(E::path('resources/custom_group_contract_updates.json'));
@@ -50,19 +50,19 @@ class CRM_Contract_Upgrader extends CRM_Extension_Upgrader_Base {
     return TRUE;
   }
 
-  public function upgrade_1370() {
+  public function upgrade_1370(): bool {
     $this->ctx->log->info('Applying update 1370');
     return TRUE;
   }
 
-  public function upgrade_1390() {
+  public function upgrade_1390(): bool {
     $this->ctx->log->info('Applying update 1390');
     $logging = new CRM_Logging_Schema();
     $logging->fixSchemaDifferences();
     return TRUE;
   }
 
-  public function upgrade_1402() {
+  public function upgrade_1402(): bool {
     $this->ctx->log->info('Applying updates for 14xx');
     $customData = new CRM_Contract_CustomData(E::LONG_NAME);
     $customData->syncOptionGroup(E::path('resources/option_group_contact_channel.json'));
@@ -71,7 +71,7 @@ class CRM_Contract_Upgrader extends CRM_Extension_Upgrader_Base {
     return TRUE;
   }
 
-  public function upgrade_1403() {
+  public function upgrade_1403(): bool {
     $this->ctx->log->info('Applying updates for 14xx');
     $customData = new CRM_Contract_CustomData(E::LONG_NAME);
     $customData->syncCustomGroup(E::path('resources/custom_group_contract_updates.json'));
@@ -79,7 +79,7 @@ class CRM_Contract_Upgrader extends CRM_Extension_Upgrader_Base {
     return TRUE;
   }
 
-  public function upgrade_1501() {
+  public function upgrade_1501(): bool {
     $this->ctx->log->info('Applying localisation');
     $customData = new CRM_Contract_CustomData(E::LONG_NAME);
     $customData->syncOptionGroup(E::path('resources/option_group_contact_channel.json'));
@@ -96,14 +96,14 @@ class CRM_Contract_Upgrader extends CRM_Extension_Upgrader_Base {
     return TRUE;
   }
 
-  public function upgrade_1502() {
+  public function upgrade_1502(): bool {
     $this->ctx->log->info('Hide/filter activity types');
     $customData = new CRM_Contract_CustomData(E::LONG_NAME);
     $customData->syncOptionGroup(E::path('resources/option_group_activity_types.json'));
     return TRUE;
   }
 
-  public function upgrade_1503() {
+  public function upgrade_1503(): bool {
     $this->ctx->log->info('Update translations');
     $customData = new CRM_Contract_CustomData(E::LONG_NAME);
     $customData->syncCustomGroup(E::path('resources/custom_group_membership_payment.json'));
@@ -111,40 +111,51 @@ class CRM_Contract_Upgrader extends CRM_Extension_Upgrader_Base {
     return TRUE;
   }
 
-  public function upgrade_2000() {
+  public function upgrade_2000(): bool {
     $this->ctx->log->info('Adjust filters for contract actions');
     $customData = new CRM_Contract_CustomData(E::LONG_NAME);
     $customData->syncOptionGroup(E::path('resources/option_group_activity_types.json'));
     return TRUE;
   }
 
-  public function upgrade_2001() {
+  public function upgrade_2001(): bool {
     $this->ctx->log->info('Update contract types');
     $customData = new CRM_Contract_CustomData(E::LONG_NAME);
     $customData->syncEntities(E::path('resources/option_group_activity_types.json'));
     return TRUE;
   }
 
-  public function upgrade_2002() {
+  public function upgrade_2002(): bool {
     $this->ctx->log->info('Delete dialoger field on contract');
     $customData = new CRM_Contract_CustomData(E::LONG_NAME);
     $customData->syncEntities(E::path('resources/custom_group_membership_general.json'));
     return TRUE;
   }
 
-  public function upgrade_2003() {
+  public function upgrade_2003(): bool {
     $this->ctx->log->info('Add "No Payment required" payment instrument.');
     $this->ensureNoPaymentRequiredPaymentInstrument();
     return TRUE;
   }
 
-  public function upgrade_2004() {
+  public function upgrade_2004(): bool {
     $this->ctx->log->info('Add ContractMembershipRelation entity schema.');
     E::schema()->createEntityTable('schema/ContractMembershipRelation.entityType.php');
     return TRUE;
   }
 
-  protected function ensureNoPaymentRequiredPaymentInstrument() {
+  public function upgrade_2005(): bool {
+    // TODO: Migrate source_record_id to custom field contract_activity.contract_id for contract activities.
+    // TODO: Use a queue.
+    $contractIds = \Civi\Api4\Activity::get(FALSE)
+      ->addSelect('id', 'source_record_id')
+      ->addWhere('activity_type_id', 'IN', \CRM_Contract_Change::getActivityTypeIds())
+      ->execute()
+      ->indexBy('id')
+      ->column('source_record_id');
+  }
+
+  protected function ensureNoPaymentRequiredPaymentInstrument(): void {
     try {
       $currentNone = OptionValue::get(FALSE)
         ->addWhere('option_group_id.name', '=', 'payment_instrument')
@@ -201,7 +212,7 @@ class CRM_Contract_Upgrader extends CRM_Extension_Upgrader_Base {
     }
   }
 
-  protected function findNextAvailablePaymentInstrumentValueByGroupName(string $groupName) {
+  protected function findNextAvailablePaymentInstrumentValueByGroupName(string $groupName): int {
     $rows = OptionValue::get(FALSE)
       ->addWhere('option_group_id.name', '=', $groupName)
       ->setSelect(['value'])

--- a/CRM/Contract/Upgrader.php
+++ b/CRM/Contract/Upgrader.php
@@ -145,14 +145,39 @@ class CRM_Contract_Upgrader extends CRM_Extension_Upgrader_Base {
   }
 
   public function upgrade_2005(): bool {
-    // TODO: Migrate source_record_id to custom field contract_activity.contract_id for contract activities.
-    // TODO: Use a queue.
+    // Migrate "source_record_id" to custom field contract_activity.contract_id for contract activities.
     $contractIds = \Civi\Api4\Activity::get(FALSE)
-      ->addSelect('id', 'source_record_id')
+      ->addSelect('id', 'source_record_id', 'membership.id')
       ->addWhere('activity_type_id', 'IN', \CRM_Contract_Change::getActivityTypeIds())
+      ->addWhere('source_record_id', 'IS NOT NULL')
+      // @phpstan-ignore argument.type
+      ->addJoin('Membership AS membership', 'LEFT', ['membership.id', '=', 'source_record_id'])
       ->execute()
       ->indexBy('id')
-      ->column('source_record_id');
+      ->column('membership.id');
+    foreach ($contractIds as $activityId => $contractId) {
+      $this->addTask(
+        E::ts('Migrate contract references for activities from "source_record_id" to entity reference field'),
+        'migrateContractReference',
+        $activityId, $contractId
+      );
+    }
+    return TRUE;
+  }
+
+  public function migrateContractReference(int $activityId, ?int $contractId): bool {
+    if (NULL === $contractId) {
+      $this->ctx->log->warning(E::ts(
+        'Referenced contract does not exist, deleting reference on activity %1.',
+        [1 => $activityId]
+      ));
+    }
+    \Civi\Api4\Activity::update(FALSE)
+      ->addValue('contract_activity.contract_id', $contractId)
+      ->addValue('source_record_id', NULL)
+      ->addWhere('id', '=', $activityId)
+      ->execute();
+    return TRUE;
   }
 
   protected function ensureNoPaymentRequiredPaymentInstrument(): void {

--- a/CRM/Contract/Upgrader.php
+++ b/CRM/Contract/Upgrader.php
@@ -150,6 +150,7 @@ class CRM_Contract_Upgrader extends CRM_Extension_Upgrader_Base {
       ->addSelect('id', 'source_record_id', 'membership.id')
       ->addWhere('activity_type_id', 'IN', \CRM_Contract_Change::getActivityTypeIds())
       ->addWhere('source_record_id', 'IS NOT NULL')
+      ->addWhere('contract_activity.contract_id', 'IS NULL')
       // @phpstan-ignore argument.type
       ->addJoin('Membership AS membership', 'LEFT', ['membership.id', '=', 'source_record_id'])
       ->execute()
@@ -174,7 +175,6 @@ class CRM_Contract_Upgrader extends CRM_Extension_Upgrader_Base {
     }
     \Civi\Api4\Activity::update(FALSE)
       ->addValue('contract_activity.contract_id', $contractId)
-      ->addValue('source_record_id', NULL)
       ->addWhere('id', '=', $activityId)
       ->execute();
     return TRUE;

--- a/CRM/Contract/Upgrader.php
+++ b/CRM/Contract/Upgrader.php
@@ -151,8 +151,7 @@ class CRM_Contract_Upgrader extends CRM_Extension_Upgrader_Base {
       ->addWhere('activity_type_id', 'IN', \CRM_Contract_Change::getActivityTypeIds())
       ->addWhere('source_record_id', 'IS NOT NULL')
       ->addWhere('contract_activity.contract_id', 'IS NULL')
-      // @phpstan-ignore argument.type
-      ->addJoin('Membership AS membership', 'LEFT', ['membership.id', '=', 'source_record_id'])
+      ->addJoin('Membership AS membership', 'LEFT', NULL, ['membership.id', '=', 'source_record_id'])
       ->execute()
       ->indexBy('id')
       ->column('membership.id');
@@ -169,7 +168,7 @@ class CRM_Contract_Upgrader extends CRM_Extension_Upgrader_Base {
   public function migrateContractReference(int $activityId, ?int $contractId): bool {
     if (NULL === $contractId) {
       $this->ctx->log->warning(E::ts(
-        'Referenced contract does not exist, deleting reference on activity %1.',
+        'Referenced contract does not exist, deleting referencing activity %1.',
         [1 => $activityId]
       ));
     }

--- a/CRM/Contract/Utils.php
+++ b/CRM/Contract/Utils.php
@@ -296,30 +296,25 @@ class CRM_Contract_Utils {
   }
 
   /**
-   * If configured this way, this call will delete the defined
-   *  list of system-generated activities
-   *
-   * @param $contract_id int the contract number
+   * If configured this way, this call will delete the defined list of system-generated activities.
    */
-  public static function deleteSystemActivities($contract_id) {
-    if (empty($contract_id)) {
+  public static function deleteSystemActivities(?int $contract_id): void {
+    if (!isset($contract_id)) {
       return;
     }
 
-    $activity_types_to_delete = CRM_Contract_Configuration::suppressSystemActivityTypes();
-    if (!empty($activity_types_to_delete)) {
-      // find them
-      $activity_search = civicrm_api3('Activity', 'get', [
-        'source_record_id'   => $contract_id,
-        'activity_type_id'   => ['IN' => $activity_types_to_delete],
-        'activity_date_time' => ['>=' => date('Ymd') . '000000'],
-        'return'             => 'id',
-      ]);
-
-      // delete them
-      foreach ($activity_search['values'] as $activity) {
-        civicrm_api3('Activity', 'delete', ['id' => $activity['id']]);
-      }
+    $activityTypesToDelete = CRM_Contract_Configuration::suppressSystemActivityTypes();
+    if ([] !== $activityTypesToDelete) {
+      \Civi\Api4\Activity::delete(FALSE)
+        // Using "source_record_id" here as Core uses that field for system membership activities.
+        ->addWhere('source_record_id', '=', $contract_id)
+        ->addWhere('activity_type_id:name', 'IN', $activityTypesToDelete)
+        ->addWhere(
+          'activity_date_time',
+          '>=',
+          date_create('today midnight')->format('Y-m-d H:i:s')
+        )
+        ->execute();
     }
   }
 
@@ -354,9 +349,9 @@ class CRM_Contract_Utils {
    *
    * @todo remove this code once APIv4 is used
    *
-   * @param array $data
+   * @phpstan-param array<string, mixed> $data
    */
-  public static function stripNonContractActivityCustomFields(array &$data) {
+  public static function stripNonContractActivityCustomFields(array &$data): void {
     // whitelist of contract activity custom fields
     $allowedFields = array_map(
       function($field) {

--- a/CRM/Contract/Utils.php
+++ b/CRM/Contract/Utils.php
@@ -299,7 +299,7 @@ class CRM_Contract_Utils {
    * If configured this way, this call will delete the defined list of system-generated activities.
    */
   public static function deleteSystemActivities(?int $contract_id): void {
-    if (!isset($contract_id)) {
+    if (NULL === $contract_id) {
       return;
     }
 

--- a/Civi/Contract/Event/DisplayChangeTitle.php
+++ b/Civi/Contract/Event/DisplayChangeTitle.php
@@ -190,22 +190,15 @@ class DisplayChangeTitle extends AbstractConfigurationEvent {
     return $this->change_activity_type_id;
   }
 
-  /**
-   * Get the ID of the change activity
-   *
-   * @return string
-   */
-  public function getActivityClass() {
+  public function getActivityClass(): ?string {
     return CRM_Contract_Change::getClassByActivityType($this->change_activity_type_id);
   }
 
-  /**
-   * Get the action name of the change
-   *
-   * @return string
-   */
-  public function getActivityAction() {
+  public function getActivityAction(): ?string {
     $class = $this->getActivityClass();
+    if (NULL === $class) {
+      throw new \RuntimeException('No class name resolved for activity type.');
+    }
     return CRM_Contract_Change::getActionByClass($class);
   }
 

--- a/api/v3/Contract/Create.php
+++ b/api/v3/Contract/Create.php
@@ -44,6 +44,10 @@ function civicrm_api3_Contract_create($params) {
   }
 
   // create
+  /** @phpstan-var array{
+   *     id: int|string
+   *   } $membership
+   */
   $membership = civicrm_api3('Membership', 'create', $params);
 
   // link SEPA Mandate
@@ -62,7 +66,7 @@ function civicrm_api3_Contract_create($params) {
     $change->setParameter('activity_date_time', $params['activity_date_time']);
   }
   $change->setParameter('source_contact_id', CRM_Contract_Configuration::getUserID());
-  $change->setParameter('source_record_id', $membership['id']);
+  $change->setParameter('contract_activity.contract_id', (int) $membership['id']);
   $change->setParameter('target_contact_id', $change->getContract()['contact_id']);
   $change->setStatus('Completed');
   $change->populateData();
@@ -76,7 +80,7 @@ function civicrm_api3_Contract_create($params) {
   );
 
   // maybe we need to do some cleanup:
-  CRM_Contract_Utils::deleteSystemActivities($membership['id']);
+  CRM_Contract_Utils::deleteSystemActivities((int) $membership['id']);
 
   return $membership;
 }

--- a/api/v3/Contract/Create.php
+++ b/api/v3/Contract/Create.php
@@ -45,7 +45,7 @@ function civicrm_api3_Contract_create($params) {
 
   // create
   /** @phpstan-var array{
-   *     id: int|string
+   *     id: int|numeric-string
    *   } $membership
    */
   $membership = civicrm_api3('Membership', 'create', $params);

--- a/api/v3/Contract/Create.php
+++ b/api/v3/Contract/Create.php
@@ -67,6 +67,7 @@ function civicrm_api3_Contract_create($params) {
   }
   $change->setParameter('source_contact_id', CRM_Contract_Configuration::getUserID());
   $change->setParameter('contract_activity.contract_id', (int) $membership['id']);
+  $change->setParameter('source_record_id', (int) $membership['id']);
   $change->setParameter('target_contact_id', $change->getContract()['contact_id']);
   $change->setStatus('Completed');
   $change->populateData();

--- a/api/v3/Contract/GetOpenModificationCounts.php
+++ b/api/v3/Contract/GetOpenModificationCounts.php
@@ -10,6 +10,8 @@
 
 declare(strict_types = 1);
 
+use Civi\Api4\Activity;
+
 /**
  * Get the number of scheduled modifications for a contract
  */
@@ -26,18 +28,24 @@ function _civicrm_api3_Contract_get_open_modification_counts_spec(&$params) {
  * Get the number of scheduled modifications for a contract
  */
 function civicrm_api3_Contract_get_open_modification_counts($params) {
-  $activitiesForReview = civicrm_api3('Activity', 'getcount', [
-    'source_record_id' => $params['id'],
-    'status_id' => 'Needs Review',
-  ]);
-  $activitiesScheduled = civicrm_api3('Activity', 'getcount', [
-    'source_record_id' => $params['id'],
-    'status_id' => ['IN' => ['Scheduled']],
-  ]);
-  $activitiesFailed = civicrm_api3('Activity', 'getcount', [
-    'source_record_id' => $params['id'],
-    'status_id' => ['IN' => ['Failed']],
-  ]);
+  $activitiesForReview = Activity::get(FALSE)
+    ->selectRowCount()
+    ->addWhere('contract_activity.contract_id', '=', $params['id'])
+    ->addWhere('status_id:name', '=', 'Needs Review')
+    ->execute()
+    ->count();
+  $activitiesScheduled = Activity::get(FALSE)
+    ->selectRowCount()
+    ->addWhere('contract_activity.contract_id', '=', $params['id'])
+    ->addWhere('status_id:name', '=', 'Scheduled')
+    ->execute()
+    ->count();
+  $activitiesFailed = Activity::get(FALSE)
+    ->selectRowCount()
+    ->addWhere('contract_activity.contract_id', '=', $params['id'])
+    ->addWhere('status_id:name', '=', 'Failed')
+    ->execute()
+    ->count();
   return civicrm_api3_create_success([
     'needs_review' => $activitiesForReview,
     'scheduled' => $activitiesScheduled,

--- a/api/v3/Contract/Modify.php
+++ b/api/v3/Contract/Modify.php
@@ -74,7 +74,7 @@ function civicrm_api3_Contract_modify($params) {
   // modify data to match internal structure
   $params['activity_type_id']   = $params['action'];
   $params['activity_date_time'] = date('Y-m-d H:i:s', $requested_execution_time);
-  $params['source_record_id']   = $params['id'];
+  $params['contract_activity.contract_id'] = (int) $params['id'];
   unset($params['id']);
   if (!empty($params['note'])) {
     $params['details'] = $params['note'];

--- a/api/v3/Contract/Modify.php
+++ b/api/v3/Contract/Modify.php
@@ -75,6 +75,7 @@ function civicrm_api3_Contract_modify($params) {
   $params['activity_type_id']   = $params['action'];
   $params['activity_date_time'] = date('Y-m-d H:i:s', $requested_execution_time);
   $params['contract_activity.contract_id'] = (int) $params['id'];
+  $params['source_record_id'] = (int) $params['id'];
   unset($params['id']);
   if (!empty($params['note'])) {
     $params['details'] = $params['note'];

--- a/api/v3/Contract/ProcessScheduledModifications.php
+++ b/api/v3/Contract/ProcessScheduledModifications.php
@@ -37,6 +37,7 @@ function _civicrm_api3_Contract_process_scheduled_modifications_spec(&$params) {
 /**
  * Process the scheduled contract modifications
  */
+// @phpcs:ignore Generic.Metrics.CyclomaticComplexity.TooHigh
 function civicrm_api3_Contract_process_scheduled_modifications($params) {
   // make sure no other task is running
   /** @var \Civi\Core\Lock\LockManager $lockManager */
@@ -60,28 +61,38 @@ function civicrm_api3_Contract_process_scheduled_modifications($params) {
     $params['limit'] = CE_ENGINE_PROCESSING_LIMIT;
   }
 
-  // compile query
-  $activityParams = [
-    'activity_type_id' => ['IN' => CRM_Contract_Change::getActivityTypeIds()],
-    'status_id' => 'scheduled',
+  $scheduledActivitiesQuery = \Civi\Api4\Activity::get(FALSE)
+    ->addSelect(
+      'id',
+      'activity_type_id',
+      'status_id',
+      'activity_date_time',
+      'subject',
+      'contract_activity.contract_id',
+      'contract_cancellation.*',
+      'contract_updates.*',
+    )
+    ->addWhere('activity_type_id', 'IN', CRM_Contract_Change::getActivityTypeIds())
+    ->addWhere('status_id:name', '=', 'Scheduled')
     // execute everything scheduled in the past
-    'activity_date_time' => ['<=' => date('Y-m-d H:i:s', strtotime($params['now'] ?? 'now'))],
-    'option.limit' => $params['limit'],
+    ->addWhere('activity_date_time', '<=', date('Y-m-d H:i:s', strtotime($params['now'] ?? 'now')))
+    ->setLimit($params['limit'])
     // in the scheduled order(!)
-    'sequential' => 1,
-    'option.sort' => 'activity_date_time ASC, id ASC',
-    'return' => 'id,activity_type_id,status_id,activity_date_time,subject,source_record_id,'
-    . CRM_Contract_Change::getCustomFieldList(),
-  ];
-  if (!empty($params['id'])) {
-    $activityParams['source_record_id'] = (int) $params['id'];
+    ->addOrderBy('activity_date_time', 'ASC')
+    ->addOrderBy('id', 'ASC');
+
+  if (is_numeric($params['id'] ?? NULL)) {
+    $scheduledActivitiesQuery->addWhere('contract_activity.contract_id', '=', (int) $params['id']);
   }
 
   // run query
   $result  = [];
   $counter = 0;
-  $scheduled_activities = civicrm_api3('Activity', 'get', $activityParams);
-  foreach ($scheduled_activities['values'] as $scheduled_activity) {
+  /** @phpstan-var list<array<string, mixed>> $scheduled_activities */
+  $scheduled_activities = $scheduledActivitiesQuery
+    ->execute()
+    ->getArrayCopy();
+  foreach ($scheduled_activities as $scheduled_activity) {
     CRM_Contract_Utils::stripNonContractActivityCustomFields($scheduled_activity);
     $counter++;
     if ($counter > $params['limit']) {
@@ -89,6 +100,7 @@ function civicrm_api3_Contract_process_scheduled_modifications($params) {
     }
 
     // execute the changes
+    // @phpstan-ignore argument.type
     $change = CRM_Contract_Change::getChangeForData($scheduled_activity);
     $result['order'][] = $change->getID();
     try {

--- a/managed/CustomGroup_contract_activity.mgd.php
+++ b/managed/CustomGroup_contract_activity.mgd.php
@@ -1,0 +1,85 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+use CRM_Contract_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'CustomGroup_contract_activity',
+    'entity' => 'CustomGroup',
+    'cleanup' => 'unused',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'contract_activity',
+        'table_name' => 'civicrm_value_contract_activity',
+        'title' => E::ts('Contract Activity'),
+        'extends' => 'Activity',
+        'extends_entity_column_value:name' => [
+          'Contract_Signed',
+          'Contract_Paused',
+          'Contract_Resumed',
+          'Contract_Updated',
+          'Contract_Cancelled',
+          'Contract_Revived',
+        ],
+        'style' => 'Inline',
+        'collapse_display' => FALSE,
+        'help_pre' => '',
+        'help_post' => '',
+        'weight' => 1,
+        'is_active' => TRUE,
+        'is_multiple' => FALSE,
+        'collapse_adv_display' => TRUE,
+        'is_reserved' => FALSE,
+        'is_public' => FALSE,
+        'icon' => '',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomField_contract_activity.contract_id',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'contract_activity',
+        'name' => 'contract_id',
+        'label' => E::ts('Contract'),
+        'data_type' => 'EntityReference',
+        'html_type' => 'Autocomplete-Select',
+        'is_reserved' => FALSE,
+        'is_required' => TRUE,
+        'is_searchable' => TRUE,
+        'is_search_range' => TRUE,
+        'column_name' => 'contract_id',
+        'in_selector' => FALSE,
+        'fk_entity' => 'Membership',
+        'fk_entity_on_delete' => 'cascade',
+      ],
+      'match' => [
+        'custom_group_id',
+        'name',
+      ],
+    ],
+  ],
+];

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1441,13 +1441,13 @@ parameters:
 		-
 			message: '#^BooleanAnd\: Condition between bool and false are always false\.$#'
 			identifier: voku.BooleanAnd
-			count: 3
+			count: 2
 			path: CRM/Contract/Form/Modify.php
 
 		-
 			message: '#^BooleanAndNode\: Condition between bool and false are always false\.$#'
 			identifier: voku.BooleanAndNode
-			count: 3
+			count: 2
 			path: CRM/Contract/Form/Modify.php
 
 		-
@@ -2672,7 +2672,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 16
+			count: 14
 			path: CRM/Contract/SepaLogic.php
 
 		-
@@ -5291,12 +5291,6 @@ parameters:
 			path: tests/phpunit/CRM/Contract/Form/ModifyFormTest.php
 
 		-
-			message: '#^Identical\: Possible insane comparison between null and float\.$#'
-			identifier: voku.Identical
-			count: 1
-			path: tests/phpunit/CRM/Contract/Form/ModifyFormTest.php
-
-		-
 			message: '#^In method "ModifyFormTest\:\:ensurePaymentInstrumentNone", caught "Throwable" must be rethrown\. Either catch a more specific exception, add a "throw" clause in the "catch" block to propagate the exception or add a "// @ignoreException" comment\.$#'
 			count: 2
 			path: tests/phpunit/CRM/Contract/Form/ModifyFormTest.php
@@ -5551,10 +5545,4 @@ parameters:
 			message: '#^Short ternary operator is not allowed\. Use null coalesce operator if applicable or consider using long ternary\.$#'
 			identifier: ternary.shortNotAllowed
 			count: 5
-			path: tests/phpunit/CRM/Contract/Form/ModifyFormTest.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between float and null will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
 			path: tests/phpunit/CRM/Contract/Form/ModifyFormTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -332,13 +332,13 @@ parameters:
 		-
 			message: '#^Cannot cast mixed to int\.$#'
 			identifier: cast.int
-			count: 2
+			count: 1
 			path: CRM/Contract/Change.php
 
 		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
-			count: 9
+			count: 8
 			path: CRM/Contract/Change.php
 
 		-
@@ -425,24 +425,6 @@ parameters:
 			path: CRM/Contract/Change.php
 
 		-
-			message: '#^Method CRM_Contract_Change\:\:getActvityTypeID\(\) should return int but returns float\|int\|string\.$#'
-			identifier: return.type
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:getChangeForData\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:getChangeForData\(\) should return CRM_Contract_Change but returns object\.$#'
-			identifier: return.type
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
 			message: '#^Method CRM_Contract_Change\:\:getChangeTypes\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -461,18 +443,6 @@ parameters:
 			path: CRM/Contract/Change.php
 
 		-
-			message: '#^Method CRM_Contract_Change\:\:getClassByActivityType\(\) has parameter \$activity_type_id with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:getClassByActivityType\(\) should return string but returns null\.$#'
-			identifier: return.type
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
 			message: '#^Method CRM_Contract_Change\:\:getContract\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -481,12 +451,6 @@ parameters:
 		-
 			message: '#^Method CRM_Contract_Change\:\:getContract\(\) should return array but returns array\|null\.$#'
 			identifier: return.type
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:getContractID\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: CRM/Contract/Change.php
 
@@ -707,24 +671,6 @@ parameters:
 			path: CRM/Contract/Change.php
 
 		-
-			message: '#^Offset ''activity_type_id'' might not exist on array\<string, mixed\>\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Offset ''source_record_id'' might not exist on array\<string, mixed\>\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Parameter \#3 \$params of function civicrm_api3 expects array, array\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
 			message: '#^Property CRM_Contract_Change\:\:\$_type_id2label type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -751,24 +697,6 @@ parameters:
 		-
 			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
 			identifier: function.strict
-			count: 1
-			path: CRM/Contract/Change/Cancel.php
-
-		-
-			message: '#^Cannot access offset ''id'' on array\|int\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: CRM/Contract/Change/Cancel.php
-
-		-
-			message: '#^Cannot access offset ''values'' on array\|int\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: CRM/Contract/Change/Cancel.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
 			count: 1
 			path: CRM/Contract/Change/Cancel.php
 
@@ -823,30 +751,6 @@ parameters:
 		-
 			message: '#^Method CRM_Contract_Change_Cancel\:\:shouldBeAccepted\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change/Cancel.php
-
-		-
-			message: '#^Offset ''activity_date_time'' might not exist on array\<string, mixed\>\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: CRM/Contract/Change/Cancel.php
-
-		-
-			message: '#^Offset ''membership_cancellation\.membership_cancel_reason'' might not exist on array\<string, mixed\>\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 2
-			path: CRM/Contract/Change/Cancel.php
-
-		-
-			message: '#^Only booleans are allowed in a ternary operator condition, string\|null given\.$#'
-			identifier: ternary.condNotBoolean
-			count: 1
-			path: CRM/Contract/Change/Cancel.php
-
-		-
-			message: '#^Parameter \#1 \$datetime of function strtotime expects string, mixed given\.$#'
-			identifier: argument.type
 			count: 1
 			path: CRM/Contract/Change/Cancel.php
 
@@ -1069,12 +973,6 @@ parameters:
 		-
 			message: '#^Method CRM_Contract_Change_Sign\:\:shouldBeAccepted\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change/Sign.php
-
-		-
-			message: '#^Only booleans are allowed in a ternary operator condition, list\<string\> given\.$#'
-			identifier: ternary.condNotBoolean
 			count: 1
 			path: CRM/Contract/Change/Sign.php
 
@@ -1309,12 +1207,6 @@ parameters:
 		-
 			message: '#^PHPDoc tag @phpstan\-return has invalid value \(\)\: Unexpected token "\\n   ", expected type at offset 78 on line 4$#'
 			identifier: phpDoc.parseError
-			count: 1
-			path: CRM/Contract/Change/Upgrade.php
-
-		-
-			message: '#^Parameter \#2 \$array of function array_key_exists expects array, array\<string, mixed\>\|null given\.$#'
-			identifier: argument.type
 			count: 1
 			path: CRM/Contract/Change/Upgrade.php
 
@@ -2258,12 +2150,6 @@ parameters:
 			path: CRM/Contract/Handler/MembershipForm.php
 
 		-
-			message: '#^Cannot access offset ''values'' on array\|int\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: CRM/Contract/Handler/ModificationConflicts.php
-
-		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
 			count: 2
@@ -2278,12 +2164,6 @@ parameters:
 		-
 			message: '#^Method CRM_Contract_Handler_ModificationConflicts\:\:checkForConflicts\(\) has parameter \$contractId with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Handler/ModificationConflicts.php
-
-		-
-			message: '#^Method CRM_Contract_Handler_ModificationConflicts\:\:getScheduledModifications\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: CRM/Contract/Handler/ModificationConflicts.php
 
@@ -2330,39 +2210,9 @@ parameters:
 			path: CRM/Contract/Handler/ModificationConflicts.php
 
 		-
-			message: '#^Property CRM_Contract_Handler_ModificationConflicts\:\:\$contractId has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: CRM/Contract/Handler/ModificationConflicts.php
-
-		-
-			message: '#^Property CRM_Contract_Handler_ModificationConflicts\:\:\$needsReviewStatusId has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: CRM/Contract/Handler/ModificationConflicts.php
-
-		-
-			message: '#^Property CRM_Contract_Handler_ModificationConflicts\:\:\$scheduledModifications has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: CRM/Contract/Handler/ModificationConflicts.php
-
-		-
-			message: '#^Cannot access offset ''contact_id'' on array\|int\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: CRM/Contract/Page/Review.php
-
-		-
-			message: '#^Cannot access offset ''payment_instrument_id'' on array\|int\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: CRM/Contract/Page/Review.php
-
-		-
 			message: '#^Cannot access offset ''values'' on array\|int\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 11
+			count: 8
 			path: CRM/Contract/Page/Review.php
 
 		-
@@ -3185,96 +3035,6 @@ parameters:
 			path: CRM/Contract/Upgrader.php
 
 		-
-			message: '#^Method CRM_Contract_Upgrader\:\:enable\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Upgrader.php
-
-		-
-			message: '#^Method CRM_Contract_Upgrader\:\:ensureNoPaymentRequiredPaymentInstrument\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Upgrader.php
-
-		-
-			message: '#^Method CRM_Contract_Upgrader\:\:findNextAvailablePaymentInstrumentValueByGroupName\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Upgrader.php
-
-		-
-			message: '#^Method CRM_Contract_Upgrader\:\:upgrade_1370\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Upgrader.php
-
-		-
-			message: '#^Method CRM_Contract_Upgrader\:\:upgrade_1390\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Upgrader.php
-
-		-
-			message: '#^Method CRM_Contract_Upgrader\:\:upgrade_1402\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Upgrader.php
-
-		-
-			message: '#^Method CRM_Contract_Upgrader\:\:upgrade_1403\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Upgrader.php
-
-		-
-			message: '#^Method CRM_Contract_Upgrader\:\:upgrade_1501\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Upgrader.php
-
-		-
-			message: '#^Method CRM_Contract_Upgrader\:\:upgrade_1502\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Upgrader.php
-
-		-
-			message: '#^Method CRM_Contract_Upgrader\:\:upgrade_1503\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Upgrader.php
-
-		-
-			message: '#^Method CRM_Contract_Upgrader\:\:upgrade_2000\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Upgrader.php
-
-		-
-			message: '#^Method CRM_Contract_Upgrader\:\:upgrade_2001\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Upgrader.php
-
-		-
-			message: '#^Method CRM_Contract_Upgrader\:\:upgrade_2002\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Upgrader.php
-
-		-
-			message: '#^Method CRM_Contract_Upgrader\:\:upgrade_2003\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Upgrader.php
-
-		-
-			message: '#^Method CRM_Contract_Upgrader\:\:upgrade_2004\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Upgrader.php
-
-		-
 			message: '#^Only booleans are allowed in &&, array given on the right side\.$#'
 			identifier: booleanAnd.rightNotBoolean
 			count: 1
@@ -3325,7 +3085,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''values'' on array\|int\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 6
+			count: 5
 			path: CRM/Contract/Utils.php
 
 		-
@@ -3337,7 +3097,7 @@ parameters:
 		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
-			count: 4
+			count: 2
 			path: CRM/Contract/Utils.php
 
 		-
@@ -3365,18 +3125,6 @@ parameters:
 
 		-
 			message: '#^Method CRM_Contract_Utils\:\:contractFilePath\(\) has parameter \$file with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Utils.php
-
-		-
-			message: '#^Method CRM_Contract_Utils\:\:deleteSystemActivities\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Utils.php
-
-		-
-			message: '#^Method CRM_Contract_Utils\:\:deleteSystemActivities\(\) has parameter \$contract_id with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: CRM/Contract/Utils.php
@@ -3486,18 +3234,6 @@ parameters:
 		-
 			message: '#^Method CRM_Contract_Utils\:\:singleton\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Utils.php
-
-		-
-			message: '#^Method CRM_Contract_Utils\:\:stripNonContractActivityCustomFields\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Utils.php
-
-		-
-			message: '#^Method CRM_Contract_Utils\:\:stripNonContractActivityCustomFields\(\) has parameter \$data with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: CRM/Contract/Utils.php
 
@@ -4118,12 +3854,6 @@ parameters:
 			path: Civi/Contract/Event/DisplayChangeTitle.php
 
 		-
-			message: '#^Method Civi\\Contract\\Event\\DisplayChangeTitle\:\:getActivityAction\(\) should return string but returns string\|null\.$#'
-			identifier: return.type
-			count: 1
-			path: Civi/Contract/Event/DisplayChangeTitle.php
-
-		-
 			message: '#^Method Civi\\Contract\\Event\\DisplayChangeTitle\:\:getChangeActivityData\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -4496,12 +4226,6 @@ parameters:
 			path: Civi/Contract/PaymentContract.php
 
 		-
-			message: '#^Cannot access offset ''id'' on array\|int\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
-			path: api/v3/Contract/Create.php
-
-		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
 			count: 1
@@ -4640,15 +4364,9 @@ parameters:
 			path: api/v3/Contract/ProcessScheduledModifications.php
 
 		-
-			message: '#^Cannot access offset ''values'' on array\|int\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: api/v3/Contract/ProcessScheduledModifications.php
-
-		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
-			count: 3
+			count: 2
 			path: api/v3/Contract/ProcessScheduledModifications.php
 
 		-

--- a/phpstan.ci.neon
+++ b/phpstan.ci.neon
@@ -14,6 +14,11 @@ parameters:
 	# Because we test with different versions in CI we may have unmatched errors.
 	reportUnmatchedIgnoredErrors: false
 	ignoreErrors:
+		# Errors caused by dependencies
+		-
+			message: '#^Identical\: Insane comparison between null and null\.$#'
+			path: CRM/Contract/SepaLogic.php
+
 		# Errors we get when using "prefer-lowest"
 
 		# Required with symfony/event-dispatcher <4.4.27

--- a/phpstan.ci.neon
+++ b/phpstan.ci.neon
@@ -15,6 +15,9 @@ parameters:
 	reportUnmatchedIgnoredErrors: false
 	ignoreErrors:
 		# Errors caused by dependencies
+
+		# Required with CiviSEPA (no fixed version yet):
+		# bogus return type hint in \CRM_Sepa_Logic_Verification::verifyIBAN()
 		-
 			message: '#^Identical\: Insane comparison between null and null\.$#'
 			path: CRM/Contract/SepaLogic.php

--- a/tests/phpunit/CRM/Contract/BasicEngineTest.php
+++ b/tests/phpunit/CRM/Contract/BasicEngineTest.php
@@ -138,7 +138,13 @@ class CRM_Contract_BasicEngineTest extends CRM_Contract_ContractTestBase {
 
       // schedule and update for tomorrow
       $this->modifyContract($contract['id'], 'pause', 'tomorrow');
-      $changes = $this->callAPISuccess('Activity', 'get', ['source_record_id' => $contract['id']]);
+      $contractReferenceFieldId = \Civi\Api4\CustomField::get(FALSE)
+        ->addSelect('id')
+        ->addWhere('custom_group_id:name', '=', 'contract_activity')
+        ->addWhere('name', '=', 'contract_id')
+        ->execute()
+        ->single()['id'];
+      $changes = $this->callAPISuccess('Activity', 'get', ['custom_' . $contractReferenceFieldId => $contract['id']]);
 
       // run engine see if anything changed
       $this->runContractEngine($contract['id']);
@@ -258,9 +264,11 @@ class CRM_Contract_BasicEngineTest extends CRM_Contract_ContractTestBase {
       'membership_payment.membership_annual' => '123.00',
     ]);
     // resolve "Needs Review"
-    CRM_Core_DAO::executeQuery(
-      "UPDATE civicrm_activity SET status_id = 1 WHERE source_record_id = {$contract['id']} AND status_id <> 2;"
-    );
+    \Civi\Api4\Activity::update(FALSE)
+      ->addValue('status_id:name', 'Scheduled')
+      ->addWhere('contract_activity.contract_id', '=', $contract['id'])
+      ->addWhere('status_id:name', '!=', 'Completed')
+      ->execute();
     // run the cancellation (but not the update)
     $this->runContractEngine($contract['id'], '+2 days');
 
@@ -276,9 +284,11 @@ class CRM_Contract_BasicEngineTest extends CRM_Contract_ContractTestBase {
       'membership_cancellation.membership_cancel_reason' => 'Unknown',
     ]);
     // resolve "Needs Review"
-    CRM_Core_DAO::executeQuery(
-      "UPDATE civicrm_activity SET status_id = 1 WHERE source_record_id = {$contract['id']} AND status_id <> 2;"
-    );
+    \Civi\Api4\Activity::update(FALSE)
+      ->addValue('status_id:name', 'Scheduled')
+      ->addWhere('contract_activity.contract_id', '=', $contract['id'])
+      ->addWhere('status_id:name', '!=', 'Completed')
+      ->execute();
     // run cancellation
     $this->callEngineFailure(
       $contract['id'],

--- a/tests/phpunit/CRM/Contract/BasicEngineTest.php
+++ b/tests/phpunit/CRM/Contract/BasicEngineTest.php
@@ -138,13 +138,6 @@ class CRM_Contract_BasicEngineTest extends CRM_Contract_ContractTestBase {
 
       // schedule and update for tomorrow
       $this->modifyContract($contract['id'], 'pause', 'tomorrow');
-      $contractReferenceFieldId = \Civi\Api4\CustomField::get(FALSE)
-        ->addSelect('id')
-        ->addWhere('custom_group_id:name', '=', 'contract_activity')
-        ->addWhere('name', '=', 'contract_id')
-        ->execute()
-        ->single()['id'];
-      $changes = $this->callAPISuccess('Activity', 'get', ['custom_' . $contractReferenceFieldId => $contract['id']]);
 
       // run engine see if anything changed
       $this->runContractEngine($contract['id']);

--- a/tests/phpunit/CRM/Contract/ContractTestBase.php
+++ b/tests/phpunit/CRM/Contract/ContractTestBase.php
@@ -442,11 +442,17 @@ class CRM_Contract_ContractTestBase extends TestCase implements HeadlessInterfac
    */
   public function getChangeActivities($contract_id, $types = NULL, $status = []) {
     // compile query
+    $contractReferenceFieldId = \Civi\Api4\CustomField::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('custom_group_id:name', '=', 'contract_activity')
+      ->addWhere('name', '=', 'contract_id')
+      ->execute()
+      ->single()['id'];
     $query = [
-      'source_record_id' => $contract_id,
-      'sequential'       => 1,
-      'option.limit'     => 0,
-      'option.sort'      => 'activity_date_time desc',
+      'custom_' . $contractReferenceFieldId => $contract_id,
+      'sequential' => 1,
+      'option.limit' => 0,
+      'option.sort' => 'activity_date_time desc',
     ];
     if (!empty($types)) {
       $query['activity_type_id'] = ['IN' => $types];

--- a/tests/phpunit/CRM/Contract/EngineStressTest.php
+++ b/tests/phpunit/CRM/Contract/EngineStressTest.php
@@ -64,9 +64,11 @@ class CRM_Contract_EngineStressTest extends CRM_Contract_ContractTestBase {
       );
 
       // cheekily set all of the 'needs review' ones to 'scheduled'
-      CRM_Core_DAO::executeQuery(
-        "UPDATE civicrm_activity SET status_id = 1 WHERE source_record_id = {$contract['id']} AND status_id <> 2;"
-      );
+      \Civi\Api4\Activity::update(FALSE)
+        ->addValue('status_id:name', 'Scheduled')
+        ->addWhere('contract_activity.contract_id', '=', $contract['id'])
+        ->addWhere('status_id:name', '!=', 'Completed')
+        ->execute();
 
       // now... these should all be scheduled
       $scheduled_updates = $this->callAPISuccess(

--- a/tests/phpunit/CRM/Contract/Form/ModifyFormTest.php
+++ b/tests/phpunit/CRM/Contract/Form/ModifyFormTest.php
@@ -963,7 +963,7 @@ class ModifyFormTest extends ContractTestBase {
         sprintf(
           'Unexpected amount on new recurring contribution. Expected: %.4f, got: %s (RC id #%s, status=%s)',
           $target,
-          $gotAmt === NULL ? '∅' : (string) $gotAmt,
+          (string) $gotAmt,
           $candidate['id'] ?? '?',
           $candidate['contribution_status_id:name'] ?? '?'
         )

--- a/tests/phpunit/Civi/Contract/Api4/Action/Contract/ModifyFullActionTest.php
+++ b/tests/phpunit/Civi/Contract/Api4/Action/Contract/ModifyFullActionTest.php
@@ -58,7 +58,7 @@ final class ModifyFullActionTest extends AbstractSetupHeadless {
     self::assertArrayHasKey('id', $modified);
 
     $activity = \Civi\Api4\Activity::get(FALSE)
-      ->addWhere('source_record_id', '=', $contract['id'])
+      ->addWhere('contract_activity.contract_id', '=', $contract['id'])
       ->addOrderBy('id', 'DESC')
       ->execute()
       ->first();
@@ -101,7 +101,7 @@ final class ModifyFullActionTest extends AbstractSetupHeadless {
     self::assertArrayHasKey('id', $modified);
 
     $activity = \Civi\Api4\Activity::get(FALSE)
-      ->addWhere('source_record_id', '=', $contract['id'])
+      ->addWhere('contract_activity.contract_id', '=', $contract['id'])
       ->addOrderBy('id', 'DESC')
       ->execute()
       ->first();
@@ -143,7 +143,7 @@ final class ModifyFullActionTest extends AbstractSetupHeadless {
     self::assertArrayHasKey('id', $modified);
 
     $activity = \Civi\Api4\Activity::get(FALSE)
-      ->addWhere('source_record_id', '=', $contract['id'])
+      ->addWhere('contract_activity.contract_id', '=', $contract['id'])
       ->addOrderBy('id', 'DESC')
       ->execute()
       ->first();
@@ -203,7 +203,7 @@ final class ModifyFullActionTest extends AbstractSetupHeadless {
     self::assertArrayHasKey('id', $modified);
 
     $activity = \Civi\Api4\Activity::get(FALSE)
-      ->addWhere('source_record_id', '=', $contract['id'])
+      ->addWhere('contract_activity.contract_id', '=', $contract['id'])
       ->addOrderBy('id', 'DESC')
       ->execute()
       ->first();
@@ -252,7 +252,7 @@ final class ModifyFullActionTest extends AbstractSetupHeadless {
     self::assertArrayHasKey('id', $modified);
 
     $activity = \Civi\Api4\Activity::get(FALSE)
-      ->addWhere('source_record_id', '=', $contract['id'])
+      ->addWhere('contract_activity.contract_id', '=', $contract['id'])
       ->addOrderBy('id', 'DESC')
       ->execute()
       ->first();
@@ -310,7 +310,7 @@ final class ModifyFullActionTest extends AbstractSetupHeadless {
     self::assertArrayHasKey('id', $modified);
 
     $activity = \Civi\Api4\Activity::get(FALSE)
-      ->addWhere('source_record_id', '=', $contract['id'])
+      ->addWhere('contract_activity.contract_id', '=', $contract['id'])
       ->addOrderBy('id', 'DESC')
       ->execute()
       ->first();
@@ -351,7 +351,7 @@ final class ModifyFullActionTest extends AbstractSetupHeadless {
     self::assertArrayHasKey('id', $modified);
 
     $activity = \Civi\Api4\Activity::get(FALSE)
-      ->addWhere('source_record_id', '=', $contract['id'])
+      ->addWhere('contract_activity.contract_id', '=', $contract['id'])
       ->addOrderBy('id', 'DESC')
       ->execute()
       ->first();


### PR DESCRIPTION
- [x] Define custom field
- [x] Use custom field instead of `source_record_id` for contract-related activities
- [x] Upgrader task for migrating data for existing activities
- [x] Fix failing tests

*systopia-reference: 32077*