### PR TITLE
Do not apply membership summary modifications on other contexts (view/add/edit/delete)

### DIFF
--- a/CRM/Contract/Change/Upgrade.php
+++ b/CRM/Contract/Change/Upgrade.php
@@ -37,7 +37,7 @@ class CRM_Contract_Change_Upgrade extends CRM_Contract_Change {
         if (!empty($this->data[$contract_attribute])) {
           // @phpstan-ignore assign.propertyType
           $this->data[$change_attribute] = $this->data[$contract_attribute];
-          $contract_after_execution[$contract_attribute] = $this->data[$contract_attribute];
+          $contract_after_execution[$contract_attribute] = $this->data[$contract_attribute] ?? NULL;
         }
       }
 

--- a/contract.php
+++ b/contract.php
@@ -82,7 +82,11 @@ function contract_civicrm_pageRun(CRM_Core_Page &$page): void {
   }
   elseif ($page_name == 'CRM_Member_Page_Tab') {
     /** @var CRM_Member_Page_Tab $page */
-    // thus is the membership summary tab
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $page);
+    if ('search' !== $context) {
+      return;
+    }
+    // This is the membership summary/list tab.
     $contractStatuses = [];
     foreach (
       civicrm_api3(


### PR DESCRIPTION
*systopia-reference: 32935*

`CRM_Member_Page_Tab` is the controller used for all of those membership pages, thus context needs to be evaluated for targeting only one of them.
