### PR TITLE
Add Upgrader task for deleting leftover activities with invalid contract references

### DIFF
--- a/CRM/Contract/Upgrader.php
+++ b/CRM/Contract/Upgrader.php
@@ -54,6 +54,10 @@ class CRM_Contract_Upgrader extends CRM_Extension_Upgrader_Base {
   }
 
   public function upgrade_2005(): bool {
+    return TRUE;
+  }
+
+  public function upgrade_2006(): bool {
     // Migrate "source_record_id" to custom field contract_activity.contract_id for contract activities.
     /** @var int $maxActivityId */
     $maxActivityId = Activity::get(FALSE)
@@ -98,11 +102,16 @@ class CRM_Contract_Upgrader extends CRM_Extension_Upgrader_Base {
           'Referenced contract does not exist, deleting referencing activity %1.',
           [1 => $activityId]
         ));
+        Activity::delete(FALSE)
+          ->addWhere('id', '=', $activityId)
+          ->execute();
       }
-      Activity::update(FALSE)
-        ->addValue('contract_activity.contract_id', $contractId)
-        ->addWhere('id', '=', $activityId)
-        ->execute();
+      else {
+        Activity::update(FALSE)
+          ->addValue('contract_activity.contract_id', $contractId)
+          ->addWhere('id', '=', $activityId)
+          ->execute();
+      }
     }
 
     return TRUE;

--- a/tests/phpunit/CRM/Contract/UpgraderTest.php
+++ b/tests/phpunit/CRM/Contract/UpgraderTest.php
@@ -28,12 +28,12 @@ class CRM_Contract_UpgraderTest extends CRM_Contract_ContractTestBase {
     self::assertSame($contractId, $this->getContractReference($activityId));
   }
 
-  public function testMigrateContractReferences_WithMissingContract_LeavesReferenceEmpty(): void {
+  public function testMigrateContractReferences_WithMissingContract_DeletesActivity(): void {
     $activityId = $this->createUnmigratedContractActivity(999999999);
 
     $this->runMigration(0, PHP_INT_MAX);
 
-    self::assertNull($this->getContractReference($activityId));
+    self::assertNull($this->getActivity($activityId));
   }
 
   public function testMigrateContractReferences_OutsideIdRange_LeavesReferenceEmpty(): void {
@@ -81,15 +81,31 @@ class CRM_Contract_UpgraderTest extends CRM_Contract_ContractTestBase {
   }
 
   private function getContractReference(int $activityId): ?int {
-    $activity = Activity::get(FALSE)
-      ->addSelect('contract_activity.contract_id')
-      ->addWhere('id', '=', $activityId)
-      ->execute()
-      ->single();
+    $activity = $this->getActivity($activityId);
 
     return isset($activity['contract_activity.contract_id'])
       ? (int) $activity['contract_activity.contract_id']
       : NULL;
+  }
+
+  /**
+   * @phpstan-return array{
+   *   "contract_activity.contract_id": int|numeric-string,
+   * }|null
+   */
+  private function getActivity(int $activityId): ?array {
+    try {
+      // @phpstan-ignore return.type
+      return Activity::get(FALSE)
+        ->addSelect('contract_activity.contract_id')
+        ->addWhere('id', '=', $activityId)
+        ->execute()
+        ->single();
+    }
+    catch (\Exception $exception) {
+      // @ignoreException
+      return NULL;
+    }
   }
 
 }


### PR DESCRIPTION
The original upgrader task for migrating from `source_record_id` to a custom entity reference field did not delete those activities, but does now. The additional upgrader task takes care of environments that already ran the incomplete original migration task.
