### PR TITLE
Refactor contract change

### DIFF
--- a/CRM/Contract/Change.php
+++ b/CRM/Contract/Change.php
@@ -11,11 +11,9 @@ declare(strict_types = 1);
 use Civi\Api4\Activity;
 use Civi\Api4\ContributionRecur;
 use Civi\Api4\Membership;
-use Civi\Api4\OptionValue;
 use Civi\Contract\Api4\Helper\FieldNameHelper;
+use Civi\Contract\ContractChange\ContractChangeInterface;
 use Civi\Contract\Event\RenderChangeSubjectEvent;
-use CRM_Contract_ExtensionUtil as E;
-use Webmozart\Assert\Assert;
 
 /**
  * Base class for contract changes. These are tracked changes to
@@ -24,8 +22,12 @@ use Webmozart\Assert\Assert;
  * This new 'Change' concept is the replacement for the CRM_Contract_ModificationActivity
  *  and the CRM_Contract_Handlers
  *
+ * Note: When data was fetched via APIv3 integers might be given as numeric
+ * strings.
  * @phpstan-type changeT array{
- *   activity_type_id: int|string,
+ *   id?: int,
+ *   "activity_type_id:name"?: string,
+ *   activity_type_id?: int,
  *   activity_date_time?: string,
  *   campaign_id?: int,
  *   membership_type_id?: int,
@@ -41,10 +43,11 @@ use Webmozart\Assert\Assert;
  *   "membership_payment.membership_recurring_contribution"?: int,
  *   "membership_payment.payment_instrument"?: int,
  *   "membership_cancellation.membership_cancel_reason"?: string,
+ *   ...
  *  }
  */
 // phpcs:disable Generic.NamingConventions.AbstractClassNamePrefix.Missing
-abstract class CRM_Contract_Change {
+abstract class CRM_Contract_Change implements ContractChangeInterface {
 // phpcs:enable
 
   /**
@@ -57,45 +60,6 @@ abstract class CRM_Contract_Change {
    * Contract data (cached)
    */
   protected ?array $contract = NULL;
-
-  /**
-   * List of known changes,
-   *  activity_type_name => change class
-   */
-  protected const TYPE2CLASS = [
-    'Contract_Signed' => 'CRM_Contract_Change_Sign',
-    'Contract_Cancelled' => 'CRM_Contract_Change_Cancel',
-    'Contract_Updated' => 'CRM_Contract_Change_Upgrade',
-    'Contract_Resumed' => 'CRM_Contract_Change_Resume',
-    'Contract_Revived' => 'CRM_Contract_Change_Revive',
-    'Contract_Paused' => 'CRM_Contract_Change_Pause',
-    'Secondary_Membership_Created' => 'CRM_Contract_Change_AddRelatedMembership',
-    'Secondary_Membership_Ended' => 'CRM_Contract_Change_EndRelatedMembership',
-  ];
-
-  /**
-   * List of known actions,
-   *  activity_type_name => change class
-   */
-  protected const ACTION2CLASS = [
-    'sign' => 'CRM_Contract_Change_Sign',
-    'cancel' => 'CRM_Contract_Change_Cancel',
-    'update' => 'CRM_Contract_Change_Upgrade',
-    'resume' => 'CRM_Contract_Change_Resume',
-    'revive' => 'CRM_Contract_Change_Revive',
-    'pause' => 'CRM_Contract_Change_Pause',
-    'add related' => 'CRM_Contract_Change_AddRelatedMembership',
-    'end related' => 'CRM_Contract_Change_EndRelatedMembership',
-  ];
-
-  /**
-   * @phpstan-var array<int|string, string>
-   * List of activity_type_id => change class
-   * Will be be populated on demand
-   */
-  protected static ?array $_type_id2class = NULL;
-
-  protected static ?array $_type_id2label = NULL;
 
   /**
    * Maps the contract fields to the change activity fields
@@ -117,100 +81,22 @@ abstract class CRM_Contract_Change {
   /**
    * @phpstan-param changeT $data
    */
-  protected function __construct(array $data) {
+  public function __construct(array $data) {
     $this->data = $data;
-    // make sure activity_type_id is numeric
-    $this->data['activity_type_id'] = $this->getActvityTypeID();
-  }
-
-  ################################################################################
-  ##                          ABSTRACT FUNCTIONS                                ##
-  ################################################################################
-
-  /**
-   * Apply the given change to the contract
-   *
-   * @throws Exception should anything go wrong in the execution
-   */
-  abstract public function execute(): void;
-
-  /**
-   * Get a list of required fields for this type
-   *
-   * @return list<string>
-   */
-  abstract public function getRequiredFields(): array;
-
-  /**
-   * Get action name for
-   *
-   * @phpstan-param array<string, mixed>|null $contract_after
-   *   Data of the contract after.
-   * @phpstan-param array<string, mixed>|null $contract_before
-   *   Data of the contract before.
-   * @return string
-   *   The subject line.
-   */
-  abstract public function renderDefaultSubject(?array $contract_after, ?array $contract_before = NULL): string;
-
-  ################################################################################
-  ##                           COMMON FUNCTIONS                                 ##
-  ################################################################################
-
-  /**
-   * Check whether this change activity should actually be created
-   *
-   * @throws Exception if the creation should be disallowed
-   */
-  public function shouldBeAccepted() {}
-
-  /**
-   * Make sure that the data for this change is valid
-   *
-   * @throws Exception if the data is not valid
-   */
-  public function verifyData() {
-    // simply check if all required fields are there
-    // ...anything else needs to be checked in the specific class...
-    $required_fields = $this->getRequiredFields();
-    foreach ($required_fields as $required_field) {
-      if (!isset($this->data[$required_field])) {
-        throw new \RuntimeException("Parameter '{$required_field}' missing.");
-      }
-    }
-  }
-
-  public function verifyStatusChange() {
-    $class = get_class($this);
-    if (!method_exists($class, 'getStartStatusList')) {
-      return;
-    }
-    $contract = $this->getContract();
-    $status_name = CRM_Contract_Utils::getMembershipStatusName($contract['status_id']);
-    if (!in_array($status_name, $class::getStartStatusList())) {
-      throw new \RuntimeException("Cannot {$this->getActionName()} a membership when its status is '{$status_name}'.");
-    }
+    $this->data['activity_type_id:name'] = $this::getActivityTypeName();
   }
 
   /**
    * Get the change ID
    */
-  public function getID() {
+  public function getID(): ?int {
     return $this->data['id'] ?? NULL;
-  }
-
-  /**
-   * Get the internal action name
-   */
-  public function getActionName() {
-    $class2action = array_flip(self::ACTION2CLASS);
-    return $class2action[get_class($this)];
   }
 
   /**
    * Get the contract ID
    */
-  public function getContractID(): ?int {
+  public function getContractID(): int {
     if (isset($this->data['contract_activity.contract_id'])) {
       $contractId = $this->data['contract_activity.contract_id'];
     }
@@ -224,13 +110,18 @@ abstract class CRM_Contract_Change {
         ->single()['id'];
       $contractId = $this->data['custom_' . $contractReferenceFieldId] ?? NULL;
     }
-    return NULL !== $contractId ? (int) $contractId : NULL;
+
+    if (NULL === $contractId) {
+      throw new RuntimeException('Contract ID not fond');
+    }
+
+    return (int) $contractId;
   }
 
   /**
    * Derive/populate additional data
    */
-  public function populateData() {
+  public function populateData(): void {
     // populate parameters
     $contract = $this->getContract(TRUE);
 
@@ -248,43 +139,41 @@ abstract class CRM_Contract_Change {
   }
 
   /**
-   * Get the contract data
-   *
-   * @param boolean $with_payment_data
-   * @return array contract data
+   * @inheritDoc
    */
-  public function getContract($with_payment_data = FALSE) {
-    $contract_id = $this->getContractID();
-    if ($this->contract === NULL || (int) $this->contract['id'] !== $contract_id) {
+  public function getContract(bool $withPaymentData = FALSE): array {
+    $contractId = $this->getContractID();
+    if ($this->contract === NULL || (int) $this->contract['id'] !== $contractId) {
       // (re)load contract
       try {
         $this->contract = Membership::get(FALSE)
           ->addSelect('*', 'custom.*')
-          ->addWhere('id', '=', $contract_id)
+          ->addWhere('id', '=', $contractId)
           ->execute()
           ->single();
       }
       catch (Exception $ex) {
-        throw new \RuntimeException("Contract [{$contract_id}] not found!", $ex->getCode(), $ex);
+        throw new \RuntimeException("Contract [{$contractId}] not found!", $ex->getCode(), $ex);
       }
     }
 
     // add the payment data, if requested
-    if ($with_payment_data) {
-      if (empty($this->contract['membership_payment.membership_frequency'])) {
+    if ($withPaymentData) {
+      if (!isset($this->contract['membership_payment.membership_frequency'])) {
         $this->derivePaymentData($this->contract);
       }
     }
 
+    // @phpstan-ignore return.type (phpstan assumes that contract might be NULL)
     return $this->contract;
   }
 
   /**
    * Enrich the given contact with payment data
    *
-   * @param $contract array contract data
+   * @param array<string, mixed> $contract contract data
    */
-  public function derivePaymentData(&$contract) {
+  public function derivePaymentData(array &$contract): void {
     if (!empty($contract['membership_payment.membership_recurring_contribution'])) {
       // we have a recurring contribution!
       try {
@@ -354,32 +243,12 @@ abstract class CRM_Contract_Change {
   }
 
   /**
-   * Get the (numeric) activity type ID
-   *
-   * @return int activity type ID
-   */
-  public function getActvityTypeID() {
-    if (is_numeric($this->data['activity_type_id'] ?? NULL)) {
-      return (int) $this->data['activity_type_id'];
-    }
-
-    // otherwise translate class to ID
-    $id2class = self::getActivityTypeId2Class();
-    $class2id = array_flip($id2class);
-    if (!isset($class2id[get_class($this)])) {
-      throw new CRM_Core_Exception('Missing contract change activity type: ' . get_class($this));
-    }
-    $activity_type_id = $class2id[get_class($this)];
-    return $activity_type_id;
-  }
-
-  /**
    * Update the contract with the given data
    *
    * @param $updates array changes: attribute->value
    * @throws Exception
    */
-  public function updateContract($updates) {
+  public function updateContract(array $updates): void {
     // make sure the ID is there
     $updates['id'] = $this->getContractID();
 
@@ -394,32 +263,23 @@ abstract class CRM_Contract_Change {
   }
 
   /**
-   * Calculate the subject line for this activity
-   *
-   * @param $contract_before array contract before update
-   * @param $contract_after  array contract after update
-   *
-   * @return string subject line
+   * @inheritDoc
    */
-  public function getSubject($contract_after, $contract_before = NULL) {
-    return $this->renderChangeSubject($this, $contract_before, $contract_after);
+  final public function getSubject(?array $contractAfter, ?array $contractBefore = NULL): string {
+    return RenderChangeSubjectEvent::renderCustomChangeSubject(
+      $this,
+      $contractBefore,
+      $contractAfter
+    ) ?? $this->renderSubject($contractAfter, $contractBefore);
   }
 
   /**
-   * Calculate the activities subject
-   *
-   * @param $change                CRM_Contract_Change the change object
-   * @param $contract_before       array  data of the contract before
-   * @param $contract_after        array  data of the contract after
-   * @return                       string the subject line
+   * @phpstan-param array<string, mixed>|null $contractAfter
+   *   Data of the contract after the change.
+   * @phpstan-param array<string, mixed>|null $contractBefore
+   *   Data of the contract before the change.
    */
-  public function renderChangeSubject($change, $contract_before, $contract_after) {
-    return RenderChangeSubjectEvent::renderCustomChangeSubject(
-      $change->getActionName(),
-      $contract_before,
-      $contract_after
-    ) ?? $change->renderDefaultSubject($contract_after, $contract_before);
-  }
+  abstract protected function renderSubject(?array $contractAfter, ?array $contractBefore): string;
 
   /**
    * Calculate annual amount
@@ -462,24 +322,17 @@ abstract class CRM_Contract_Change {
   }
 
   /**
-   * Set a parameter with the activity
-   *
-   * @param string $key property name
-   * @param mixed $value value to set
+   * @inheritDoc
    */
-  public function setParameter($key, $value) {
+  public function setParameter(string $key, mixed $value): void {
     // @phpstan-ignore assign.propertyType
     $this->data[$key] = $value;
   }
 
   /**
-   * Get a parameter from the activity
-   *
-   * @param string $key property name
-   * @param mixed $default default to return if not set
-   * @return mixed value in the activity data
+   * @inheritDoc
    */
-  public function getParameter($key, $default = NULL) {
+  public function getParameter(string $key, mixed $default = NULL): mixed {
     return $this->data[$key]
       ?? CRM_Utils_Request::retrieve($key, 'String')
       ?? $default;
@@ -488,7 +341,7 @@ abstract class CRM_Contract_Change {
   /**
    * Save data to the DB (activity)
    */
-  public function save() {
+  public function save(): void {
     // make sure all custom fields are transformed into the 'custom_[id]' notation
     $mitigation_ch_defer_payment_start_value = $this->data['membership_payment.defer_payment_start'] ?? 0;
 
@@ -527,8 +380,8 @@ abstract class CRM_Contract_Change {
   /**
    * Check if this change is new, i.e. has not yet been saved to the DB
    */
-  public function isNew() {
-    return empty($this->data['id']);
+  public function isNew(): bool {
+    return !isset($this->data['id']);
   }
 
   /**
@@ -536,14 +389,8 @@ abstract class CRM_Contract_Change {
    *
    * @param string $status valid activity status
    */
-  public function setStatus($status): void {
+  public function setStatus(string $status): void {
     $this->data['status_id'] = $status;
-  }
-
-  public function checkForConflicts() {
-    // TODO: refactor CRM_Contract_Handler_ModificationConflicts
-    $conflictHandler = new CRM_Contract_Handler_ModificationConflicts();
-    $conflictHandler->checkForConflicts($this->getContractID());
   }
 
   /**
@@ -711,226 +558,6 @@ abstract class CRM_Contract_Change {
       default:
         return $value;
     }
-  }
-
-  ################################################################################
-  ##                           STATIC FUNCTIONS                                 ##
-  ################################################################################
-
-  /**
-   * @param $membership_data
-   * @param $links
-   */
-  public static function modifyActionLinks($membership_data, &$links) {
-    // first remove the default ones that shouldn't be used any more
-    $obsolete_actions = [
-      CRM_Core_Action::RENEW,
-      CRM_Core_Action::FOLLOWUP,
-      CRM_Core_Action::DELETE,
-      CRM_Core_Action::UPDATE,
-    ];
-    foreach ($links as $key => $link) {
-      if (in_array($link['bit'], $obsolete_actions)) {
-        unset($links[$key]);
-      }
-    }
-
-    // add the replacement actions
-    $status_name = CRM_Contract_Utils::getMembershipStatusName($membership_data['status_id']);
-    foreach (self::getActivityTypeId2Class() as $change_class) {
-      if (method_exists($change_class, 'modifyMembershipActionLinks')) {
-        $change_class::modifyMembershipActionLinks($links, $status_name, $membership_data);
-      }
-    }
-  }
-
-  /**
-   * Get the class for the given activity type
-   *
-   * @param int|string $activity_type
-   *   Acitivity type ID, name, or change action name.
-   */
-  public static function getClassByActivityType($activity_type): ?string {
-    // check name -> class mapping first
-    if (isset(self::TYPE2CLASS[$activity_type])) {
-      return self::TYPE2CLASS[$activity_type];
-    }
-
-    // check action -> class mapping second
-    if (isset(self::ACTION2CLASS[$activity_type])) {
-      return self::ACTION2CLASS[$activity_type];
-    }
-
-    // then try ID -> class
-    $type_id2class = self::getActivityTypeId2Class();
-    if (isset($type_id2class[$activity_type])) {
-      return $type_id2class[$activity_type];
-    }
-
-    // not found? not one of ours!
-    return NULL;
-  }
-
-  public static function getActionLabels(): array {
-    if (!isset(self::$_type_id2label)) {
-      self::$_type_id2label = Civi\Api4\OptionValue::get(FALSE)
-        ->addSelect('value', 'label')
-        ->addWhere('name', 'IN', array_keys(\CRM_Contract_Change::TYPE2CLASS))
-        ->execute()
-        ->indexBy('value')
-        ->column('label');
-    }
-    return self::$_type_id2label;
-  }
-
-  /**
-   * Get the class for the given activity type
-   *
-   * @param $action string action name, e.g. 'cancel'
-   * @return string class name
-   */
-  public static function getClassByAction($action) {
-    return self::ACTION2CLASS[strtolower($action)] ?? NULL;
-  }
-
-  /**
-   * Get the action name for the given class name.
-   *
-   * @param string $className
-   *   Action class name.
-   *
-   * @return string|null
-   *   Action name, e.g. 'cancel'.
-   */
-  public static function getActionByClass(string $className): ?string {
-    return array_flip(self::ACTION2CLASS)[$className] ?? NULL;
-  }
-
-  /**
-   * Get the list of activity type ID to class
-   *
-   * @return array activity_type_id => class name
-   */
-  public static function getActivityTypeId2Class() {
-    if (self::$_type_id2class === NULL) {
-      // populate on demand:
-      self::$_type_id2class = [];
-      /** @var \ArrayObject<int, array{value: string, name: string}> $activityTypes */
-      $activityTypes = OptionValue::get(FALSE)
-        ->addSelect('value', 'name')
-        ->addWhere('option_group_id.name', '=', 'activity_type')
-        ->addWhere('name', 'IN', array_keys(self::TYPE2CLASS))
-        ->execute();
-      foreach ($activityTypes as $entry) {
-        self::$_type_id2class[$entry['value']] = self::TYPE2CLASS[$entry['name']];
-      }
-    }
-    return self::$_type_id2class;
-  }
-
-  /**
-   * Get the list of valid activity type IDs representing changes
-   */
-  public static function getActivityTypeIds() {
-    $id2class = self::getActivityTypeId2Class();
-    return array_keys($id2class);
-  }
-
-  /**
-   * Get the activity type ID for the given change class
-   *
-   * @param string $change_class the change classe
-   * @return int associated activity type ID
-   */
-  public static function getActivityIdForClass($change_class) {
-    $class2id = array_flip(self::getActivityTypeId2Class());
-    return $class2id[$change_class] ?? NULL;
-  }
-
-  /**
-   * Get a list of all change (activity) types with label
-   *
-   * @return array [activity_type_id => activity label]
-   */
-  public static function getChangeTypes() {
-    static $changeTypes = NULL;
-    if ($changeTypes === NULL) {
-      $changeTypes = [];
-      /** @var \ArrayObject<int, array{value: string, label: string}> $activityTypes */
-      $activityTypes = OptionValue::get(FALSE)
-        ->addSelect('value', 'label')
-        ->addWhere('option_group_id.name', '=', 'activity_type')
-        ->addWhere('value', 'IN', self::getActivityTypeIds())
-        ->execute();
-      foreach ($activityTypes as $activityType) {
-        $changeTypes[$activityType['value']] = $activityType['label'];
-      }
-    }
-    return $changeTypes;
-  }
-
-  /**
-   * Get a change with data
-   *
-   * @param changeT $data
-   * @return \CRM_Contract_Change change entity
-   * @throws \RuntimeException if the change type couldn't be detected from the activity_type_id
-   */
-  public static function getChangeForData($data) {
-    if (empty($data['activity_type_id'])) {
-      throw new \RuntimeException('No activity_type_id given.');
-    }
-
-    /** @var class-string<\CRM_Contract_Change>|null $change_class */
-    $change_class = self::getClassByActivityType($data['activity_type_id']);
-    if (NULL === $change_class) {
-      throw new \RuntimeException(
-        "Activity type ID '{$data['activity_type_id']}' is not a valid contract change type."
-      );
-    }
-
-    // make sure we're using the descriptive indices, not the custom_[id] ones
-    CRM_Contract_CustomData::labelCustomFields($data);
-
-    // finally: create a change object on the data
-    return new $change_class($data);
-  }
-
-  /**
-   * Get a comma separated list of all change activity custom fields
-   *
-   * @phpstan-return list<string>
-   *   list of field names
-   */
-  public static function getCustomFieldList() {
-    $field_names = [];
-    $fields = CRM_Contract_CustomData::getCustomFieldsForGroups(['contract_cancellation', 'contract_updates']);
-    return array_column($fields, 'name');
-  }
-
-  /**
-   * Convert the given contract data and convert it to change activity data
-   *
-   * @param $data array       the data
-   * @param $reverse boolean  reverse the transition
-   */
-  public static function convertContract2ChangeData($data, $reverse = FALSE) {
-    $mapping = self::FIELD_MAPPING_CHANGE_CONTRACT;
-    if ($reverse) {
-      $mapping = array_flip($mapping);
-    }
-
-    foreach ($mapping as $old_attribute => $new_attribute) {
-      if (isset($data[$old_attribute])) {
-        $data[$new_attribute] = $data[$old_attribute];
-        unset($data[$old_attribute]);
-      }
-    }
-    return $data;
-  }
-
-  public function __toString() {
-    return $this->getActionName();
   }
 
 }

--- a/CRM/Contract/Change/AddRelatedMembership.php
+++ b/CRM/Contract/Change/AddRelatedMembership.php
@@ -21,30 +21,22 @@ use CRM_Contract_ExtensionUtil as E;
 
 class CRM_Contract_Change_AddRelatedMembership extends CRM_Contract_Change {
 
-  public const CONTRACT_ACTION = 'add related';
+  public static function getActivityTypeName(): string {
+    return 'Secondary_Membership_Created';
+  }
 
-  /**
-   * @inheritDoc
-   */
-  public function execute(): void {
-    throw new \RuntimeException(
-      // phpcs:ignore Generic.Files.LineLength.TooLong
-      'Creations of related memberships are documentary, they cannot be scheduled into the future, and therefore not executed.'
-    );
+  public static function getActivityTypeIcon(): string {
+    return 'fa-person-circle-plus';
+  }
+
+  public static function getTitle(): string {
+    return E::ts('Create Secondary Membership');
   }
 
   /**
    * @inheritDoc
    */
-  public function getRequiredFields(): array {
-    // None required because change is documentary.
-    return [];
-  }
-
-  /**
-   * @inheritDoc
-   */
-  public function renderDefaultSubject(?array $contract_after, ?array $contract_before = NULL): string {
+  public function renderSubject(?array $contractAfter, ?array $contractBefore = NULL): string {
     return E::ts('New related membership');
   }
 

--- a/CRM/Contract/Change/Cancel.php
+++ b/CRM/Contract/Change/Cancel.php
@@ -10,15 +10,32 @@ declare(strict_types = 1);
 
 use Civi\Api4\Activity;
 use Civi\Api4\MembershipStatus;
+use Civi\Contract\ContractChange\ContractChangeTypeContainer;
 use CRM_Contract_ExtensionUtil as E;
 
 /**
  * "Cancel Membership" change
  */
-class CRM_Contract_Change_Cancel extends CRM_Contract_Change {
+class CRM_Contract_Change_Cancel extends CRM_Contract_SchedulableChange {
 
   private const MEMBERSHIP_CANCEL_REASON = 'membership_cancellation.membership_cancel_reason';
   private const MEMBERSHIP_CANCEL_DATE   = 'membership_cancellation.membership_cancel_date';
+
+  public static function getActionName(): string {
+    return 'cancel';
+  }
+
+  public static function getActivityTypeName(): string {
+    return 'Contract_Cancelled';
+  }
+
+  public static function getActivityTypeIcon(): string {
+    return 'fa-stop-circle-o';
+  }
+
+  public static function getTitle(): string {
+    return E::ts('Cancel Contract');
+  }
 
   /**
    * Get a list of required fields for this type
@@ -34,7 +51,7 @@ class CRM_Contract_Change_Cancel extends CRM_Contract_Change {
   /**
    * Derive/populate additional data
    */
-  public function populateData() {
+  public function populateData(): void {
     if ($this->isNew()) {
       $this->setParameter(
         'contract_cancellation.contact_history_cancel_reason',
@@ -92,7 +109,7 @@ class CRM_Contract_Change_Cancel extends CRM_Contract_Change {
    *
    * @throws Exception if the creation should be disallowed
    */
-  public function shouldBeAccepted() {
+  public function shouldBeAccepted(): void {
     parent::shouldBeAccepted();
 
     // check for OTHER CANCELLATION REQUEST for the same day
@@ -108,7 +125,7 @@ class CRM_Contract_Change_Cancel extends CRM_Contract_Change {
       ->addSelect('id', 'activity_date_time')
       ->addWhere('activity_date_time', 'IS NOT NULL')
       ->addWhere('contract_activity.contract_id', '=', $this->getContractID())
-      ->addWhere('activity_type_id', '=', $this->getActvityTypeID())
+      ->addWhere('activity_type_id:name', '=', self::getActivityTypeName())
       ->addWhere('status_id:name', '=', 'Scheduled')
       ->execute()
       ->getArrayCopy();
@@ -137,7 +154,7 @@ class CRM_Contract_Change_Cancel extends CRM_Contract_Change {
       $pendingActivityCount = Activity::get(FALSE)
         ->selectRowCount()
         ->addWhere('contract_activity.contract_id', '=', $this->getContractID())
-        ->addWhere('activity_type_id', 'IN', CRM_Contract_Change::getActivityTypeIds())
+        ->addWhere('activity_type_id:name', 'IN', ContractChangeTypeContainer::getInstance()->getActivityTypes())
         ->addWhere('status_id:name', 'IN', ['Scheduled', 'Needs Review'])
         ->execute()
         ->countMatched();
@@ -150,7 +167,7 @@ class CRM_Contract_Change_Cancel extends CRM_Contract_Change {
   /**
    * @inheritDoc
    */
-  public function renderDefaultSubject(?array $contract_after, ?array $contract_before = NULL): string {
+  public function renderSubject(?array $contractAfter, ?array $contractBefore = NULL): string {
     if ($this->isNew()) {
       return E::ts('Contract cancellation scheduled');
     }
@@ -169,35 +186,28 @@ class CRM_Contract_Change_Cancel extends CRM_Contract_Change {
   }
 
   /**
-   * Get a list of the status names that this change can be applied to
-   *
-   * @return array list of membership status names
+   * @inheritDoc
    */
-  public static function getStartStatusList() {
+  public static function getStartStatusList(): array {
     return ['New', 'Grace', 'Current', 'Pending'];
-  }
-
-  /**
-   * Get a (human readable) title of this change
-   *
-   * @return string title
-   */
-  public static function getChangeTitle() {
-    return E::ts('Cancel Contract');
   }
 
   /**
    * Modify action links provided to the user for a given membership
    *
-   * @param $links                array  currently given links
-   * @param $current_status_name  string membership status as a string
-   * @param $membership_data      array  all known information on the membership in question
+   * @param array<int, array<string, mixed>> $links currently given links
+   * @param string $current_status_name membership status as a string
+   * @param array<string, mixed> $membership_data all known information on the membership in question
    */
-  public static function modifyMembershipActionLinks(&$links, $current_status_name, $membership_data) {
-    if (in_array($current_status_name, self::getStartStatusList())) {
+  public static function modifyMembershipActionLinks(
+    array &$links,
+    string $current_status_name,
+    array $membership_data
+  ): void {
+    if (in_array($current_status_name, self::getStartStatusList(), TRUE)) {
       $links[] = [
         'name'  => E::ts('Cancel'),
-        'title' => self::getChangeTitle(),
+        'title' => self::getTitle(),
         'url'   => 'civicrm/contract/modify',
         'bit'   => CRM_Core_Action::UPDATE,
         'qs'    => 'modify_action=cancel&id=%%id%%',

--- a/CRM/Contract/Change/EndRelatedMembership.php
+++ b/CRM/Contract/Change/EndRelatedMembership.php
@@ -21,30 +21,22 @@ use CRM_Contract_ExtensionUtil as E;
 
 class CRM_Contract_Change_EndRelatedMembership extends CRM_Contract_Change {
 
-  public const CONTRACT_ACTION = 'end related';
+  public static function getActivityTypeName(): string {
+    return 'Secondary_Membership_Ended';
+  }
 
-  /**
-   * @inheritDoc
-   */
-  public function execute(): void {
-    throw new \RuntimeException(
-      // phpcs:ignore Generic.Files.LineLength.TooLong
-      'Terminations of related memberships are documentary, they cannot be scheduled into the future, and therefore not executed.'
-    );
+  public static function getActivityTypeIcon(): string {
+    return 'fa-person-circle-minus';
+  }
+
+  public static function getTitle(): string {
+    return E::ts('End Secondary Membership');
   }
 
   /**
    * @inheritDoc
    */
-  public function getRequiredFields(): array {
-    // None required because change is documentary.
-    return [];
-  }
-
-  /**
-   * @inheritDoc
-   */
-  public function renderDefaultSubject(?array $contract_after, ?array $contract_before = NULL): string {
+  public function renderSubject(?array $contractAfter, ?array $contractBefore = NULL): string {
     return E::ts('Related membership ended');
   }
 

--- a/CRM/Contract/Change/Pause.php
+++ b/CRM/Contract/Change/Pause.php
@@ -8,12 +8,29 @@
 
 declare(strict_types = 1);
 
+use Civi\Contract\ContractChange\ContractChangeFactory;
 use CRM_Contract_ExtensionUtil as E;
 
 /**
  * "Pause Membership" change
  */
-class CRM_Contract_Change_Pause extends CRM_Contract_Change {
+class CRM_Contract_Change_Pause extends CRM_Contract_SchedulableChange {
+
+  public static function getActionName(): string {
+    return 'pause';
+  }
+
+  public static function getActivityTypeName(): string {
+    return 'Contract_Paused';
+  }
+
+  public static function getActivityTypeIcon(): string {
+    return 'fa-pause-circle-o';
+  }
+
+  public static function getTitle(): string {
+    return E::ts('Pause Contract');
+  }
 
   /**
    * Get a list of required fields for this type
@@ -34,7 +51,7 @@ class CRM_Contract_Change_Pause extends CRM_Contract_Change {
   /**
    * Derive/populate additional data
    */
-  public function populateData() {
+  public function populateData(): void {
     $contract = $this->getContract();
 
     $resume_date = $this->getParameter('resume_date');
@@ -53,13 +70,15 @@ class CRM_Contract_Change_Pause extends CRM_Contract_Change {
   /**
    * In this case, don't only just save the pause, but also the resume!
    */
-  public function save() {
+  public function save(): void {
     if ($this->isNew()) {
       // create resume change activity:
       $resume_date = $this->getParameter('resume_date');
       if ($resume_date) {
         $contract = $this->getContract();
-        $resume_change = CRM_Contract_Change::getChangeForData(['activity_type_id' => 'Contract_Resumed']);
+        $resume_change = ContractChangeFactory::getInstance()->create([
+          'activity_type_id:name' => CRM_Contract_Change_Resume::getActivityTypeName(),
+        ]);
         $resume_change->setParameter('activity_date_time', $resume_date);
         $resume_change->setParameter('contract_activity.contract_id', $this->getContractID());
         $resume_change->setParameter('source_record_id', $this->getContractID());
@@ -83,7 +102,7 @@ class CRM_Contract_Change_Pause extends CRM_Contract_Change {
 
     // pause the mandate
     $payment_contract_id = $contract['membership_payment.membership_recurring_contribution'] ?? NULL;
-    if ($payment_contract_id) {
+    if (NULL !== $payment_contract_id) {
       CRM_Contract_SepaLogic::pauseSepaMandate($payment_contract_id);
       $this->updateContract(['status_id:name' => 'Paused']);
     }
@@ -100,7 +119,7 @@ class CRM_Contract_Change_Pause extends CRM_Contract_Change {
    *
    * @throws Exception if the data is not valid
    */
-  public function verifyData() {
+  public function verifyData(): void {
     parent::verifyData();
 
     // check that the resume date is not on the same day as the pause
@@ -118,7 +137,7 @@ class CRM_Contract_Change_Pause extends CRM_Contract_Change {
    *
    * @throws Exception if the creation should be disallowed
    */
-  public function shouldBeAccepted() {
+  public function shouldBeAccepted(): void {
     // TODO: any restrictions?
     parent::shouldBeAccepted();
   }
@@ -126,7 +145,7 @@ class CRM_Contract_Change_Pause extends CRM_Contract_Change {
   /**
    * @inheritDoc
    */
-  public function renderDefaultSubject(?array $contract_after, ?array $contract_before = NULL): string {
+  public function renderSubject(?array $contractAfter, ?array $contractBefore = NULL): string {
     $resume = $this->getParameter('resume_date');
     if ($this->isNew()) {
       return $resume
@@ -139,35 +158,28 @@ class CRM_Contract_Change_Pause extends CRM_Contract_Change {
   }
 
   /**
-   * Get a list of the status names that this change can be applied to
-   *
-   * @return array list of membership status names
+   * @inheritDoc
    */
-  public static function getStartStatusList() {
+  public static function getStartStatusList(): array {
     return ['New', 'Grace', 'Current'];
-  }
-
-  /**
-   * Get a (human readable) title of this change
-   *
-   * @return string title
-   */
-  public static function getChangeTitle() {
-    return E::ts('Pause Contract');
   }
 
   /**
    * Modify action links provided to the user for a given membership
    *
-   * @param $links                array  currently given links
-   * @param $current_status_name  string membership status as a string
-   * @param $membership_data      array  all known information on the membership in question
+   * @param array<int, array<string, mixed>> $links currently given links
+   * @param string $current_status_name membership status as a string
+   * @param array<string, mixed> $membership_data all known information on the membership in question
    */
-  public static function modifyMembershipActionLinks(&$links, $current_status_name, $membership_data) {
-    if (in_array($current_status_name, self::getStartStatusList())) {
+  public static function modifyMembershipActionLinks(
+    array &$links,
+    string $current_status_name,
+    array $membership_data
+  ): void {
+    if (in_array($current_status_name, self::getStartStatusList(), TRUE)) {
       $links[] = [
         'name'  => E::ts('Pause'),
-        'title' => self::getChangeTitle(),
+        'title' => self::getTitle(),
         'url'   => 'civicrm/contract/modify',
         'bit'   => CRM_Core_Action::UPDATE,
         'qs'    => 'modify_action=pause&id=%%id%%',

--- a/CRM/Contract/Change/Resume.php
+++ b/CRM/Contract/Change/Resume.php
@@ -13,7 +13,23 @@ use CRM_Contract_ExtensionUtil as E;
 /**
  * "Resume Membership" change
  */
-class CRM_Contract_Change_Resume extends CRM_Contract_Change {
+class CRM_Contract_Change_Resume extends CRM_Contract_SchedulableChange {
+
+  public static function getActionName(): string {
+    return 'resume';
+  }
+
+  public static function getActivityTypeName(): string {
+    return 'Contract_Resumed';
+  }
+
+  public static function getActivityTypeIcon(): string {
+    return 'fa-play-circle-o';
+  }
+
+  public static function getTitle(): string {
+    return E::ts('Resume Contract');
+  }
 
   /**
    * Get a list of required fields for this type
@@ -34,7 +50,7 @@ class CRM_Contract_Change_Resume extends CRM_Contract_Change {
 
     // pause the mandate
     $payment_contract_id = $contract['membership_payment.membership_recurring_contribution'] ?? NULL;
-    if ($payment_contract_id) {
+    if (NULL !== $payment_contract_id) {
       CRM_Contract_SepaLogic::resumeSepaMandate($payment_contract_id);
       $this->updateContract(['status_id:name' => 'Current']);
     }
@@ -49,7 +65,7 @@ class CRM_Contract_Change_Resume extends CRM_Contract_Change {
   /**
    * @inheritDoc
    */
-  public function renderDefaultSubject(?array $contract_after, ?array $contract_before = NULL): string {
+  public function renderSubject(?array $contractAfter, ?array $contractBefore = NULL): string {
     if ($this->isNew()) {
       return E::ts('Resume contract');
     }
@@ -57,21 +73,10 @@ class CRM_Contract_Change_Resume extends CRM_Contract_Change {
   }
 
   /**
-   * Get a list of the status names that this change can be applied to
-   *
-   * @return array list of membership status names
+   * @inheritDoc
    */
-  public static function getStartStatusList() {
+  public static function getStartStatusList(): array {
     return ['Paused'];
-  }
-
-  /**
-   * Get a (human readable) title of this change
-   *
-   * @return string title
-   */
-  public static function getChangeTitle() {
-    return E::ts('Resume Contract');
   }
 
 }

--- a/CRM/Contract/Change/Sign.php
+++ b/CRM/Contract/Change/Sign.php
@@ -15,54 +15,32 @@ use CRM_Contract_ExtensionUtil as E;
  */
 class CRM_Contract_Change_Sign extends CRM_Contract_Change {
 
-  /**
-   * Get a list of required fields for this type
-   *
-   * @phpstan-return list<string>
-   */
-  public function getRequiredFields(): array {
-    // none required because change is documentary
-    return [];
+  public static function getActivityTypeName(): string {
+    return 'Contract_Signed';
   }
 
-  /**
-   * Apply the given change to the contract
-   *
-   * @throws Exception should anything go wrong in the execution
-   */
-  public function execute(): void {
-    throw new \RuntimeException(
-      'New membership sign-ups are documentary, they cannot be scheduled into the future, and therefore not executed.'
-    );
+  public static function getActivityTypeIcon(): string {
+    return 'fa-dot-circle-o';
+  }
+
+  public static function getTitle(): string {
+    return E::ts('Sign Contract');
   }
 
   /**
    * Derive/populate additional data
    */
-  public function populateData() {
+  public function populateData(): void {
     parent::populateData();
     $contract = $this->getContract(TRUE);
     $this->data['contract_updates.ch_annual_diff'] = $contract['membership_payment.membership_annual'] ?? 0.0;
   }
 
   /**
-   * Check whether this change activity should actually be created
-   *
-   * CANCEL activities should not be created, if there is another one already there
-   *
-   * @throws Exception if the creation should be disallowed
-   */
-  public function shouldBeAccepted() {
-    parent::shouldBeAccepted();
-
-    // TODO: check if the parameters are good
-  }
-
-  /**
    * @inheritDoc
    */
-  public function renderDefaultSubject(?array $contract_after, ?array $contract_before = NULL):string {
-    $c = (array) $contract_after;
+  public function renderSubject(?array $contractAfter, ?array $contractBefore = NULL):string {
+    $c = (array) $contractAfter;
     $parts = [];
     $type = isset($c['membership_type_id'])
       ? $this->labelValue($c['membership_type_id'], 'membership_type_id')
@@ -93,24 +71,6 @@ class CRM_Contract_Change_Sign extends CRM_Contract_Change {
     }
     $suffix = [] !== $parts ? (' — ' . implode(' • ', $parts)) : '';
     return E::ts('New membership contract') . $suffix;
-  }
-
-  /**
-   * Get a (human readable) title of this change
-   *
-   * @return string title
-   */
-  public static function getChangeTitle() {
-    return E::ts('Sign Contract');
-  }
-
-  /**
-   * Get a list of the status names that this change can be applied to
-   *
-   * @return array list of membership status names
-   */
-  public static function getStartStatusList() {
-    return [];
   }
 
 }

--- a/CRM/Contract/Change/Update.php
+++ b/CRM/Contract/Change/Update.php
@@ -11,41 +11,31 @@ declare(strict_types = 1);
 use CRM_Contract_ExtensionUtil as E;
 
 /**
- * "Revive Membership" change
+ * "Update Membership" change
  */
-class CRM_Contract_Change_Revive extends CRM_Contract_Change_UpdateBase {
+class CRM_Contract_Change_Update extends CRM_Contract_Change_UpdateBase {
 
   public static function getActionName(): string {
-    return 'revive';
+    return 'update';
   }
 
   public static function getActivityTypeName(): string {
-    return 'Contract_Revived';
+    return 'Contract_Updated';
   }
 
   public static function getActivityTypeIcon(): string {
-    return 'fa-play-circle-o';
+    return 'fa-arrow-circle-o-up';
   }
 
   public static function getTitle(): string {
-    return E::ts('Revive Contract');
-  }
-
-  /**
-   * @inheritDoc
-   */
-  public function updateContract(array $updates): void {
-    // Revive does all the same things as Upgrade, except it also removes end_date and sets status
-    $updates['end_date'] = '';
-    $updates['status_id:name'] = 'Current';
-    parent::updateContract($updates);
+    return E::ts('Update Contract');
   }
 
   /**
    * @inheritDoc
    */
   public static function getStartStatusList(): array {
-    return ['Cancelled'];
+    return ['New', 'Grace', 'Current'];
   }
 
   /**
@@ -62,12 +52,11 @@ class CRM_Contract_Change_Revive extends CRM_Contract_Change_UpdateBase {
   ): void {
     if (in_array($current_status_name, self::getStartStatusList(), TRUE)) {
       $links[] = [
-        'name'  => E::ts('Revive'),
+        'name'  => E::ts('Update'),
         'title' => self::getTitle(),
         'url'   => 'civicrm/contract/modify',
         'bit'   => CRM_Core_Action::UPDATE,
-        'qs'    => 'modify_action=revive&id=%%id%%',
-        'weight' => 30,
+        'qs'    => 'modify_action=update&id=%%id%%',
       ];
     }
   }

--- a/CRM/Contract/Change/UpdateBase.php
+++ b/CRM/Contract/Change/UpdateBase.php
@@ -11,20 +11,18 @@ declare(strict_types = 1);
 use Civi\Api4\ContributionRecur;
 use CRM_Contract_ExtensionUtil as E;
 
-/**
- * "Upgrade Membership" change
- */
-class CRM_Contract_Change_Upgrade extends CRM_Contract_Change {
+// phpcs:ignore Generic.NamingConventions.AbstractClassNamePrefix.Missing
+abstract class CRM_Contract_Change_UpdateBase extends CRM_Contract_SchedulableChange {
 
   /**
-   * Get a list of required fields for this type
+   * @inheritDoc
    */
   public function getRequiredFields(): array {
     return [];
   }
 
   /**
-   * Derive/populate additional data
+   * @inheritDoc
    */
   public function populateData(): void {
     if ($this->isNew()) {
@@ -157,9 +155,8 @@ class CRM_Contract_Change_Upgrade extends CRM_Contract_Change {
     ];
   }
 
-// phpcs:disable Generic.Metrics.CyclomaticComplexity.TooHigh, Drupal.WhiteSpace.ScopeIndent.IncorrectExact
+  // phpcs:ignore Generic.Metrics.CyclomaticComplexity.TooHigh
   public function execute(): void {
-// phpcs:enable
     $contract_before = $this->getContract(TRUE);
     $contract_update = [];
 
@@ -271,7 +268,7 @@ class CRM_Contract_Change_Upgrade extends CRM_Contract_Change {
       $contract,
       $this->data,
       $this->data,
-      $this->getActionName()
+      $this::getActionName()
     );
   }
 
@@ -378,13 +375,13 @@ class CRM_Contract_Change_Upgrade extends CRM_Contract_Change {
   /**
    * @inheritDoc
    */
-  public function renderDefaultSubject(?array $contract_after, ?array $contract_before = NULL): string {
+  public function renderSubject(?array $contractAfter, ?array $contractBefore = NULL): string {
     if ($this->isNew()) {
       return E::ts('Update contract scheduled');
     }
 
-    $before = (array) ($contract_before ?? []);
-    $after  = (array) $contract_after;
+    $before = (array) ($contractBefore ?? []);
+    $after  = (array) $contractAfter;
 
     $map = [
       'membership_type_id'                      => E::ts('Type'),
@@ -418,43 +415,6 @@ class CRM_Contract_Change_Upgrade extends CRM_Contract_Change {
       return E::ts('Contract updated');
     }
     return E::ts('Contract updated') . ' — ' . implode('; ', $changes);
-  }
-
-  /**
-   * Get a list of the status names that this change can be applied to
-   *
-   * @return array list of membership status names
-   */
-  public static function getStartStatusList() {
-    return ['New', 'Grace', 'Current'];
-  }
-
-  /**
-   * Get a (human readable) title of this change
-   *
-   * @return string title
-   */
-  public static function getChangeTitle() {
-    return E::ts('Update Contract');
-  }
-
-  /**
-   * Modify action links provided to the user for a given membership
-   *
-   * @param list<array<string, mixed>> $links currently given links
-   * @param string $current_status_name membership status as a string
-   * @param array<string, mixed> $membership_data all known information on the membership in question
-   */
-  public static function modifyMembershipActionLinks(&$links, $current_status_name, $membership_data) {
-    if (in_array($current_status_name, self::getStartStatusList())) {
-      $links[] = [
-        'name'  => E::ts('Update'),
-        'title' => self::getChangeTitle(),
-        'url'   => 'civicrm/contract/modify',
-        'bit'   => CRM_Core_Action::UPDATE,
-        'qs'    => 'modify_action=update&id=%%id%%',
-      ];
-    }
   }
 
 }

--- a/CRM/Contract/Form/Modify.php
+++ b/CRM/Contract/Form/Modify.php
@@ -10,6 +10,7 @@
 
 declare(strict_types = 1);
 
+use Civi\Contract\ContractChange\ContractChangeTypeContainer;
 use CRM_Contract_ExtensionUtil as E;
 
 class CRM_Contract_Form_Modify extends CRM_Core_Form {
@@ -20,7 +21,12 @@ class CRM_Contract_Form_Modify extends CRM_Core_Form {
 
   protected ?array $membership = NULL;
 
-  protected ?string $change_class = NULL;
+  /**
+   * @var class-string<\Civi\Contract\ContractChange\SchedulableContractChangeInterface>
+   *
+   * @phpstan-ignore property.uninitialized
+   */
+  protected string $change_class;
 
   protected ?array $contact = NULL;
 
@@ -73,17 +79,15 @@ class CRM_Contract_Form_Modify extends CRM_Core_Form {
     }
 
     // Process the requested action
-    $this->modify_action = $this->get('modify_action')
+    /** @var string $modifyAction */
+    $modifyAction = $this->modify_action = $this->get('modify_action')
       ?? strtolower(CRM_Utils_Request::retrieve('modify_action', 'String'));
-    $this->set('modify_action', $this->modify_action);
-    $this->assign('modificationActivity', $this->modify_action);
-    $this->change_class = CRM_Contract_Change::getClassByAction($this->modify_action);
-    if (empty($this->change_class)) {
-      throw new \RuntimeException(E::ts("Unknown action '%1'.", [1 => $this->modify_action]));
-    }
+    $this->set('modify_action', $modifyAction);
+    $this->assign('modificationActivity', $modifyAction);
+    $this->change_class = ContractChangeTypeContainer::getInstance()->getClassForAction($modifyAction);
 
     // set title
-    CRM_Utils_System::setTitle($this->change_class::getChangeTitle());
+    CRM_Utils_System::setTitle($this->change_class::getTitle());
 
     // Set the destination for the form
     $this->controller->_destination = CRM_Utils_System::url(
@@ -105,7 +109,7 @@ class CRM_Contract_Form_Modify extends CRM_Core_Form {
 
     // Validate that the contract has a valid start status
     $membershipStatus = CRM_Contract_Utils::getMembershipStatusName($this->membership['status_id']);
-    if (!in_array($membershipStatus, $this->change_class::getStartStatusList())) {
+    if (!in_array($membershipStatus, $this->change_class::getStartStatusList(), TRUE)) {
       throw new \RuntimeException("Invalid modification for status '{$membershipStatus}'.");
     }
   }
@@ -149,7 +153,7 @@ class CRM_Contract_Form_Modify extends CRM_Core_Form {
     $this->addButtons([
     // since Cancel looks bad when viewed next to the Cancel action
       ['type' => 'cancel', 'name' => E::ts('Discard changes'), 'submitOnce' => TRUE],
-      ['type' => 'submit', 'name' => $this->change_class::getChangeTitle(), 'isDefault' => TRUE, 'submitOnce' => TRUE],
+      ['type' => 'submit', 'name' => $this->change_class::getTitle(), 'isDefault' => TRUE, 'submitOnce' => TRUE],
     ]);
 
     $this->setDefaults();

--- a/CRM/Contract/Handler/ModificationConflicts.php
+++ b/CRM/Contract/Handler/ModificationConflicts.php
@@ -12,6 +12,8 @@
 
 declare(strict_types = 1);
 
+use Civi\Contract\ContractChange\ContractChangeTypeContainer;
+
 class CRM_Contract_Handler_ModificationConflicts {
 
   /**
@@ -121,14 +123,13 @@ class CRM_Contract_Handler_ModificationConflicts {
     $pauseActivity  = current($this->scheduledModifications);
     $resumeActivity = next($this->scheduledModifications);
 
+    $typeContainer = ContractChangeTypeContainer::getInstance();
     if (
-      (int) $pauseActivity['activity_type_id'] === CRM_Contract_Change::getActivityIdForClass(
-        'CRM_Contract_Change_Pause'
-      )
+      (int) $pauseActivity['activity_type_id'] === $typeContainer
+        ->getActivityTypeId(CRM_Contract_Change_Pause::getActivityTypeName())
       && FALSE !== $resumeActivity
-      && (int) $resumeActivity['activity_type_id'] === CRM_Contract_Change::getActivityIdForClass(
-        'CRM_Contract_Change_Resume'
-      )
+      && (int) $resumeActivity['activity_type_id'] === $typeContainer
+        ->getActivityTypeId(CRM_Contract_Change_Resume::getActivityTypeName())
     ) {
       $this->scheduledModifications = [];
     }

--- a/CRM/Contract/Page/Review.php
+++ b/CRM/Contract/Page/Review.php
@@ -10,12 +10,13 @@
 
 declare(strict_types = 1);
 
+use Civi\Contract\ContractChange\ContractChangeTypeContainer;
 use Civi\Contract\Event\DisplayChangeTitle as DisplayChangeTitle;
 
 class CRM_Contract_Page_Review extends CRM_Core_Page {
 
-  // phpcs:disable Generic.Metrics.CyclomaticComplexity.MaxExceeded, Drupal.WhiteSpace.ScopeIndent.IncorrectExact
-  public function run() {
+  // phpcs:disable Generic.Metrics.CyclomaticComplexity.TooHigh, Drupal.WhiteSpace.ScopeIndent.IncorrectExact
+  public function run(): void {
   // phpcs:enable
     // get the adjustments
     $adjustments = \Civi\Contract\Event\AdjustContractReviewEvent::getContractReviewAdjustments();
@@ -50,7 +51,7 @@ class CRM_Contract_Page_Review extends CRM_Core_Page {
       )
       ->addWhere('contract_activity.contract_id', '=', $id)
       ->addWhere('status_id:name', 'NOT IN', ['Cancelled'])
-      ->addWhere('activity_type_id', 'IN', CRM_Contract_Change::getActivityTypeIds())
+      ->addWhere('activity_type_id:name', 'IN', ContractChangeTypeContainer::getInstance()->getActivityTypes())
       ->addOrderBy('activity_date_time', 'DESC')
       ->addOrderBy('id', 'DESC')
       ->execute()
@@ -191,21 +192,12 @@ class CRM_Contract_Page_Review extends CRM_Core_Page {
     }
     $this->assign('paymentFrequencies', $paymentFrequencies);
 
-    // Get activity types
-    $this->assign('activityTypes', CRM_Contract_Change::getChangeTypes());
-    $this->assign('includeWysiwygEditor', TRUE);
-
     // Get membership types
     $membershipTypes = [];
     foreach (civicrm_api3('MembershipType', 'get', [])['values'] as $membershipType) {
       $membershipTypes[$membershipType['id']] = $membershipType['name'];
     }
     $this->assign('membershipTypes', $membershipTypes);
-
-    // since Civi 4.7, wysiwyg/ckeditor is a default core resource
-    if (version_compare(CRM_Utils_System::version(), '4.7', '<')) {
-      CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'packages/ckeditor/ckeditor.js');
-    }
 
     // hide some columns
     $this->assign('hide_columns', $adjustments->getHiddenColumnIndices());

--- a/CRM/Contract/SchedulableChange.php
+++ b/CRM/Contract/SchedulableChange.php
@@ -1,0 +1,55 @@
+<?php
+/*-------------------------------------------------------------+
+| SYSTOPIA Contract Extension                                  |
+| Copyright (C) 2019 SYSTOPIA                                  |
+| Author: B. Endres (endres -at- systopia.de)                  |
+| http://www.systopia.de/                                      |
++--------------------------------------------------------------*/
+
+declare(strict_types = 1);
+
+use Civi\Contract\ContractChange\SchedulableContractChangeInterface;
+
+/**
+ * Base class for schedulable contract changes.
+ */
+// phpcs:ignore Generic.NamingConventions.AbstractClassNamePrefix.Missing, Generic.Files.LineLength.TooLong
+abstract class CRM_Contract_SchedulableChange extends CRM_Contract_Change implements SchedulableContractChangeInterface {
+
+  /**
+   * @inheritDoc
+   */
+  public function shouldBeAccepted(): void {}
+
+  /**
+   * @inheritDoc
+   */
+  public function verifyData(): void {
+    // simply check if all required fields are there
+    // ...anything else needs to be checked in the specific class...
+    $required_fields = $this->getRequiredFields();
+    foreach ($required_fields as $required_field) {
+      if (!isset($this->data[$required_field])) {
+        throw new \RuntimeException("Parameter '{$required_field}' missing.");
+      }
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function verifyStatusChange(): void {
+    $contract = $this->getContract();
+    $status_name = CRM_Contract_Utils::getMembershipStatusName($contract['status_id']);
+    if (!in_array($status_name, $this::getStartStatusList(), TRUE)) {
+      throw new \RuntimeException("Cannot {$this::getActionName()} a membership when its status is '{$status_name}'.");
+    }
+  }
+
+  public function checkForConflicts(): void {
+    // TODO: refactor CRM_Contract_Handler_ModificationConflicts
+    $conflictHandler = new CRM_Contract_Handler_ModificationConflicts();
+    $conflictHandler->checkForConflicts($this->getContractID());
+  }
+
+}

--- a/CRM/Contract/Upgrader.php
+++ b/CRM/Contract/Upgrader.php
@@ -10,6 +10,7 @@
 
 declare(strict_types = 1);
 
+use Civi\Contract\ContractChange\ContractChangeTypeContainer;
 use CRM_Contract_ExtensionUtil as E;
 use Civi\Api4\Activity;
 use Civi\Api4\OptionValue;
@@ -62,7 +63,7 @@ class CRM_Contract_Upgrader extends CRM_Extension_Upgrader_Base {
     /** @var int $maxActivityId */
     $maxActivityId = Activity::get(FALSE)
       ->addSelect('MAX(id) AS max_id')
-      ->addWhere('activity_type_id', 'IN', \CRM_Contract_Change::getActivityTypeIds())
+      ->addWhere('activity_type_id:name', 'IN', ContractChangeTypeContainer::getInstance()->getActivityTypes())
       ->execute()
       ->first()['max_id'] ?? 0;
     for ($fromId = 0; $fromId < $maxActivityId; $fromId += self::CONTRACT_REFERENCE_BATCH_SIZE) {
@@ -86,7 +87,7 @@ class CRM_Contract_Upgrader extends CRM_Extension_Upgrader_Base {
     $contractIds = Activity::get(FALSE)
       ->addSelect('id', 'source_record_id', 'membership.id')
       ->addJoin('Membership AS membership', 'LEFT', NULL, ['membership.id', '=', 'source_record_id'])
-      ->addWhere('activity_type_id', 'IN', \CRM_Contract_Change::getActivityTypeIds())
+      ->addWhere('activity_type_id:name', 'IN', ContractChangeTypeContainer::getInstance()->getActivityTypes())
       ->addWhere('source_record_id', 'IS NOT NULL')
       ->addWhere('contract_activity.contract_id', 'IS NULL')
       ->addWhere('id', '>', $fromId)

--- a/Civi/Api4/Contract.php
+++ b/Civi/Api4/Contract.php
@@ -25,6 +25,7 @@ use Civi\Contract\Api4\Action\Contract\EndRelatedMembershipAction;
 use Civi\Contract\Api4\Action\Contract\CreateFullAction;
 use Civi\Contract\Api4\Action\Contract\GetFieldsAction;
 use Civi\Contract\Api4\Action\Contract\ModifyFullAction;
+use Civi\Contract\Api4\Action\Contract\SuspendPaymentAction;
 
 class Contract extends AbstractEntity {
 
@@ -59,6 +60,10 @@ class Contract extends AbstractEntity {
 
   public static function endRelatedMembership(bool $checkPermissions = TRUE): EndRelatedMembershipAction {
     return \Civi::service(EndRelatedMembershipAction::class)->setCheckPermissions($checkPermissions);
+  }
+
+  public static function suspendPayment(bool $checkPermissions = TRUE): SuspendPaymentAction {
+    return (new SuspendPaymentAction())->setCheckPermissions($checkPermissions);
   }
 
 }

--- a/Civi/Contract/ActionProvider/Action/UpdateContract.php
+++ b/Civi/Contract/ActionProvider/Action/UpdateContract.php
@@ -208,21 +208,6 @@ class UpdateContract extends AbstractAction {
   }
 
   /**
-   * Get a list of all modify actions
-   */
-  protected function getModifyActions() {
-    $modify_actions = [
-      'sign' => 'sign',
-      'cancel' => 'cancel',
-      'update' => 'update',
-      'resume' => 'resume',
-      'revive' => 'revive',
-      'pause' => 'pause',
-    ];
-    return $modify_actions;
-  }
-
-  /**
    * Get a list of all membership types
    */
   protected function getMembershipTypes() {

--- a/Civi/Contract/ContractChange/ContractChangeFactory.php
+++ b/Civi/Contract/ContractChange/ContractChangeFactory.php
@@ -1,0 +1,79 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Contract\ContractChange;
+
+/**
+ * @phpstan-import-type changeT from \CRM_Contract_Change
+ */
+final class ContractChangeFactory {
+
+  public static function getInstance(): self {
+    /** @var self */
+    return \Civi::service(self::class);
+  }
+
+  public function __construct(
+    private readonly ContractChangeTypeContainer $typeContainer
+  ) {}
+
+  /**
+   * @phpstan-param changeT $data
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \InvalidArgumentException
+   *   If no activity type is given or the type is not a contract change type.
+   */
+  public function create(array $data): ContractChangeInterface {
+    if (isset($data['activity_type_id:name'])) {
+      $changeClass = $this->typeContainer->getClassForActivityType($data['activity_type_id:name']);
+    }
+    elseif (isset($data['activity_type_id'])) {
+      $changeClass = $this->typeContainer->getClassForActivityTypeId($data['activity_type_id']);
+    }
+    else {
+      throw new \InvalidArgumentException('No activity type given');
+    }
+
+    // make sure we're using the descriptive indices, not the custom_[id] ones
+    \CRM_Contract_CustomData::labelCustomFields($data);
+
+    // finally: create a change object on the data
+    return new $changeClass($data);
+  }
+
+  /**
+   * @phpstan-param changeT $data
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \InvalidArgumentException
+   *   If no activity type is given or the type is not a schedulable contract
+   *   change type.
+   */
+  public function createSchedulable(array $data): SchedulableContractChangeInterface {
+    $change = $this->create($data);
+    if (!$change instanceof SchedulableContractChangeInterface) {
+      throw new \InvalidArgumentException('The given activity type is not a schedulable contract change type');
+    }
+
+    return $change;
+  }
+
+}

--- a/Civi/Contract/ContractChange/ContractChangeInterface.php
+++ b/Civi/Contract/ContractChange/ContractChangeInterface.php
@@ -1,0 +1,94 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Contract\ContractChange;
+
+interface ContractChangeInterface {
+
+  public static function getActivityTypeName(): string;
+
+  public static function getActivityTypeIcon(): ?string;
+
+  public static function getTitle(): string;
+
+  /**
+   * Calculate the subject line for this activity
+   *
+   * @phpstan-param array<string, mixed>|null $contractAfter
+   *   Data of the contract after the change.
+   * @phpstan-param array<string, mixed>|null $contractBefore
+   *   Data of the contract before the change.
+   */
+  public function getSubject(?array $contractAfter, ?array $contractBefore = NULL): string;
+
+  /**
+   * Get the change ID
+   */
+  public function getID(): ?int;
+
+  /**
+   * Get the contract ID
+   */
+  public function getContractID(): int;
+
+  /**
+   * Derive/populate additional data
+   */
+  public function populateData(): void;
+
+  /**
+   * Get the contract data
+   *
+   * @return array<string, mixed> contract data
+   */
+  public function getContract(bool $withPaymentData = FALSE): array;
+
+  /**
+   * Update the contract with the given data
+   *
+   * @param array<string, mixed> $updates changes: attribute->value
+   *
+   * @throws \Exception
+   */
+  public function updateContract(array $updates): void;
+
+  /**
+   * Set a parameter with the activity.
+   */
+  public function setParameter(string $key, mixed $value): void;
+
+  /**
+   * Get a parameter from the activity
+   */
+  public function getParameter(string $key, mixed $default = NULL): mixed;
+
+  /**
+   * Save data to the DB (activity)
+   */
+  public function save(): void;
+
+  /**
+   * Set change status
+   *
+   * @param string $status valid activity status
+   */
+  public function setStatus(string $status): void;
+
+}

--- a/Civi/Contract/ContractChange/ContractChangeTypeContainer.php
+++ b/Civi/Contract/ContractChange/ContractChangeTypeContainer.php
@@ -1,0 +1,151 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Contract\ContractChange;
+
+use Civi\Api4\OptionValue;
+
+final class ContractChangeTypeContainer {
+
+  /**
+   * @var ?array<int, string>
+   */
+  private ?array $activityTypesById = NULL;
+
+  /**
+   * @var array<string, class-string<SchedulableContractChangeInterface>>
+   */
+  private array $classesByAction = [];
+
+  /**
+   * @var array<string, class-string<ContractChangeInterface>>
+   */
+  private array $classesByActivityType = [];
+
+  public static function getInstance(): self {
+    /** @var self */
+    return \Civi::service(self::class);
+  }
+
+  /**
+   * @param list<class-string<ContractChangeInterface>> $classes
+   */
+  public function __construct(array $classes) {
+    foreach ($classes as $class) {
+      if (is_a($class, SchedulableContractChangeInterface::class, TRUE)) {
+        $this->classesByAction[$class::getActionName()] = $class;
+      }
+      $this->classesByActivityType[$class::getActivityTypeName()] = $class;
+    }
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function getActivityTypeId(string $activityTypeName): int {
+    return array_flip($this->getActivityTypesById())[$activityTypeName];
+  }
+
+  /**
+   * @return list<int>
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function getActivityTypeIds(): array {
+    return array_keys($this->getActivityTypesById());
+  }
+
+  /**
+   * @return list<string>
+   */
+  public function getActivityTypes(): array {
+    return array_keys($this->classesByActivityType);
+  }
+
+  /**
+   * @return class-string<SchedulableContractChangeInterface>
+   */
+  public function getClassForAction(string $action): string {
+    if (!isset($this->classesByAction[$action])) {
+      throw new \InvalidArgumentException(
+        "Action '$action' is not a valid contract change action."
+      );
+    }
+
+    return $this->classesByAction[$action];
+  }
+
+  /**
+   * @return class-string<ContractChangeInterface>
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \InvalidArgumentException
+   *    If the given activity type is not a contract change type.
+   */
+  public function getClassForActivityTypeId(int $activityTypeId): string {
+    $activityTypeName = $this->getActivityTypesById()[$activityTypeId] ?? NULL;
+    if (NULL === $activityTypeName) {
+      throw new \InvalidArgumentException(
+        "Activity type ID '$activityTypeId' is not a valid contract change type."
+      );
+    }
+
+    return $this->getClassForActivityType($activityTypeName);
+  }
+
+  /**
+   * @return class-string<ContractChangeInterface>
+   *
+   * @throws \InvalidArgumentException
+   *   If the given activity type is not a contract change type.
+   */
+  public function getClassForActivityType(string $activityTypeName): string {
+    if (!isset($this->classesByActivityType[$activityTypeName])) {
+      throw new \InvalidArgumentException(
+        "Activity type name '$activityTypeName' is not a valid contract change type."
+      );
+    }
+
+    return $this->classesByActivityType[$activityTypeName];
+  }
+
+  /**
+   * @return array<string, class-string<\Civi\Contract\ContractChange\ContractChangeInterface>>
+   */
+  public function getClassesByActivityType(): array {
+    return $this->classesByActivityType;
+  }
+
+  /**
+   * @return array<int, string>
+   *
+   * @throws \CRM_Core_Exception
+   */
+  private function getActivityTypesById(): array {
+    return $this->activityTypesById ??= OptionValue::get(FALSE)
+      ->addSelect('value', 'name')
+      ->addWhere('option_group_id.name', '=', 'activity_type')
+      ->addWhere('name', 'IN', $this->getActivityTypes())
+      ->execute()
+      ->indexBy('value')
+      ->column('name');
+  }
+
+}

--- a/Civi/Contract/ContractChange/SchedulableContractChangeInterface.php
+++ b/Civi/Contract/ContractChange/SchedulableContractChangeInterface.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Contract\ContractChange;
+
+interface SchedulableContractChangeInterface extends ContractChangeInterface {
+
+  /**
+   * Get the internal action name
+   */
+  public static function getActionName(): string;
+
+  /**
+   * Apply the given change to the contract
+   *
+   * @throws \Exception should anything go wrong in the execution
+   */
+  public function execute(): void;
+
+  public function checkForConflicts(): void;
+
+  /**
+   * Get a list of required fields for this type
+   *
+   * @return list<string>
+   */
+  public function getRequiredFields(): array;
+
+  /**
+   * Check whether this change activity should actually be created
+   *
+   * @throws \Exception if the creation should be disallowed
+   */
+  public function shouldBeAccepted(): void;
+
+  /**
+   * Make sure that the data for this change is valid
+   *
+   * @throws \Exception if the data is not valid
+   */
+  public function verifyData(): void;
+
+  /**
+   * @throws \Exception if status change is not possible.
+   */
+  public function verifyStatusChange(): void;
+
+  /**
+   * @return list<string>
+   *   Membership status names that this change can be applied to.
+   */
+  public static function getStartStatusList(): array;
+
+}

--- a/Civi/Contract/ContractManager.php
+++ b/Civi/Contract/ContractManager.php
@@ -20,6 +20,9 @@ declare(strict_types = 1);
 namespace Civi\Contract;
 
 use Civi\Api4\Membership;
+use Civi\Contract\ContractChange\ContractChangeFactory;
+use Civi\Contract\ContractChange\ContractChangeInterface;
+use Civi\Contract\ContractChange\SchedulableContractChangeInterface;
 
 /**
  * @phpstan-import-type changeT from \CRM_Contract_Change
@@ -30,6 +33,15 @@ class ContractManager {
    * @phpstan-var array<int, \Civi\Contract\Contract>
    */
   private array $contracts = [];
+
+  public static function getInstance(): self {
+    /** @var self */
+    return \Civi::service(self::class);
+  }
+
+  public function __construct(
+    private readonly ContractChangeFactory $contractChangeFactory
+  ) {}
 
   public function getContract(int $membershipId): Contract {
     if (!isset($this->contracts[$membershipId])) {
@@ -79,10 +91,9 @@ class ContractManager {
     $this->createContractChange(
       $contract->getMembershipId(),
       [
-        'activity_type_id' => \CRM_Contract_Change_AddRelatedMembership::CONTRACT_ACTION,
+        'activity_type_id:name' => \CRM_Contract_Change_AddRelatedMembership::getActivityTypeName(),
         'activity_date_time' => $startDate->format('Y-m-d H:i:s'),
-      ],
-      'Completed'
+      ]
     );
 
     return $relatedMembership['id'];
@@ -99,33 +110,32 @@ class ContractManager {
     $this->createContractChange(
       $contract->getMembershipId(),
       [
-        'activity_type_id' => \CRM_Contract_Change_EndRelatedMembership::CONTRACT_ACTION,
+        'activity_type_id:name' => \CRM_Contract_Change_EndRelatedMembership::getActivityTypeName(),
         'activity_date_time' => $endDate->format('Y-m-d H:i:s'),
-      ],
-      'Completed'
+      ]
     );
   }
 
   /**
    * @phpstan-param changeT $changeData
+   *
+   * @throws \CRM_Core_Exception
    */
   public function createContractChange(
     int $membershipId,
-    array $changeData,
-    string $status = 'Scheduled'
-  ): \CRM_Contract_Change {
-    $change = \CRM_Contract_Change::getChangeForData($changeData);
-    if (isset($changeData['activity_date_time'])) {
-      $change->setParameter('activity_date_time', $changeData['activity_date_time']);
-    }
+    array $changeData
+  ): ContractChangeInterface {
+    $change = $this->contractChangeFactory->create($changeData);
     $change->setParameter('source_contact_id', \CRM_Contract_Configuration::getUserID());
     $change->setParameter('contract_activity.contract_id', $membershipId);
     $change->setParameter('source_record_id', $membershipId);
     $change->setParameter('target_contact_id', $change->getContract()['contact_id']);
-    $change->setStatus($status);
+    $change->setStatus($change instanceof SchedulableContractChangeInterface ? 'Scheduled' : 'Completed');
     $change->populateData();
-    $change->verifyData();
-    $change->shouldBeAccepted();
+    if ($change instanceof SchedulableContractChangeInterface) {
+      $change->verifyData();
+      $change->shouldBeAccepted();
+    }
     $change->save();
     return $change;
   }

--- a/Civi/Contract/Event/DisplayChangeTitle.php
+++ b/Civi/Contract/Event/DisplayChangeTitle.php
@@ -11,8 +11,8 @@ declare(strict_types = 1);
 namespace Civi\Contract\Event;
 
 use Civi;
-use CRM_Contract_Change as CRM_Contract_Change;
-use civicrm_api3 as civicrm_api3;
+use Civi\Contract\ContractChange\ContractChangeTypeContainer;
+use Civi\Contract\ContractChange\SchedulableContractChangeInterface;
 
 /**
  * Class DisplayChangeTitle
@@ -30,67 +30,56 @@ class DisplayChangeTitle extends AbstractConfigurationEvent {
 
   /**
    * The change activity ID
-   *
-   * @var integer
    */
-  protected $change_activity_id;
+  protected int $change_activity_id;
 
   /**
    * The change activity type ID
-   *
-   * @var integer
    */
-  protected $change_activity_type_id;
+  protected int $change_activity_type_id;
 
   /**
    * The change activity data
-   *
-   * @var array
    */
-  protected $change_activity_data = NULL;
+  protected ?array $change_activity_data = NULL;
 
   /**
    * The change's display title
-   *
-   * @var string|null
    */
-  protected $change_activity_display_title = NULL;
+  protected ?string $change_activity_display_title = NULL;
 
   /**
    * The change's hover title
-   *
-   * @var string|null
    */
-  protected $change_activity_display_hover_title = NULL;
+  protected ?string $change_activity_display_hover_title = NULL;
 
   /**
    * Symfony event to allow customisation of a contract change event subject
    *
-   * @param integer $change_activity_type_id
+   * @param int $change_activity_type_id
    *   the change activity type ID
    *
-   * @param integer $change_activity_id
+   * @param int $change_activity_id
    *   the change activity
    */
-  public function __construct($change_activity_type_id, $change_activity_id) {
+  public function __construct(int $change_activity_type_id, int $change_activity_id) {
     $this->change_activity_id = $change_activity_id;
     $this->change_activity_type_id = $change_activity_type_id;
-    $this->change_activity_display_title = NULL;
-    $this->change_activity_display_hover_title = NULL;
   }
 
   /**
    * Symfony event to allow customisation of a contract change event subject
    *
-   * @param integer $change_activity_type_id
+   * @param int $change_activity_type_id
    *   the change activity type ID
    *
-   * @param integer $change_activity_id
+   * @param int $change_activity_id
    *   the change activity
-   *
-   * @return DisplayChangeTitle;
    */
-  public static function renderDisplayChangeTitleAndHoverText($change_activity_type_id, $change_activity_id) {
+  public static function renderDisplayChangeTitleAndHoverText(
+    int $change_activity_type_id,
+    int $change_activity_id
+  ): self {
     $event = new DisplayChangeTitle($change_activity_type_id, $change_activity_id);
     Civi::dispatcher()->dispatch(self::EVENT_NAME, $event);
     return $event;
@@ -101,14 +90,13 @@ class DisplayChangeTitle extends AbstractConfigurationEvent {
    *
    * @return string
    */
-  public function getDisplayTitle() {
+  public function getDisplayTitle(): string {
     if ($this->change_activity_display_title !== NULL) {
       return $this->change_activity_display_title;
     }
     else {
       // Default is activity type label.
-      $type_id2label = \CRM_Contract_Change::getActionLabels();
-      return $type_id2label[$this->change_activity_type_id];
+      return $this->getActivityClass()::getTitle();
     }
   }
 
@@ -118,7 +106,7 @@ class DisplayChangeTitle extends AbstractConfigurationEvent {
    * @param $title
    *   the display title to be displayed for this activity
    */
-  public function setDisplayTitle($title) {
+  public function setDisplayTitle(string $title): void {
     $this->change_activity_display_title = $title;
   }
 
@@ -127,7 +115,7 @@ class DisplayChangeTitle extends AbstractConfigurationEvent {
    *
    * @return string
    */
-  public function getDisplayHover() {
+  public function getDisplayHover(): string {
     if ($this->change_activity_display_hover_title !== NULL) {
       return $this->change_activity_display_hover_title;
     }
@@ -143,7 +131,7 @@ class DisplayChangeTitle extends AbstractConfigurationEvent {
    * @param $title
    *   the display hover title to be displayed for this activity
    */
-  public function setDisplayHoverTitle($title) {
+  public function setDisplayHoverTitle(string $title): void {
     $this->change_activity_display_hover_title = $title;
   }
 
@@ -152,21 +140,22 @@ class DisplayChangeTitle extends AbstractConfigurationEvent {
    *
    * @return array activity data
    */
-  public function getChangeActivityData() {
+  public function getChangeActivityData(): array {
     if (empty($this->change_activity_data) && !empty($this->getActivityID())) {
       // todo: isn't that cached somewhere?
+      // @phpstan-ignore assign.propertyType
       $this->change_activity_data = civicrm_api3('Activity', 'getsingle', ['id' => $this->getActivityID()]);
       \CRM_Contract_CustomData::labelCustomFields($this->change_activity_data);
     }
-    return $this->change_activity_data;
+    return $this->change_activity_data ?? [];
   }
 
   /**
    * Returns true if the action is scheduled, or false if it's already been executed or cancelled
    *
-   * @return boolean is scheduled
+   * @return bool is scheduled
    */
-  public function isActionScheduled() {
+  public function isActionScheduled(): bool {
     $data = $this->getChangeActivityData();
     // Completed
     return ($data['status_id'] != 2);
@@ -177,7 +166,7 @@ class DisplayChangeTitle extends AbstractConfigurationEvent {
    *
    * @return int
    */
-  public function getActivityID() {
+  public function getActivityID(): int {
     return $this->change_activity_id;
   }
 
@@ -186,20 +175,26 @@ class DisplayChangeTitle extends AbstractConfigurationEvent {
    *
    * @return int
    */
-  public function getActivityTypeID() {
+  public function getActivityTypeID(): int {
     return $this->change_activity_type_id;
   }
 
-  public function getActivityClass(): ?string {
-    return CRM_Contract_Change::getClassByActivityType($this->change_activity_type_id);
+  /**
+   * @return class-string<\Civi\Contract\ContractChange\ContractChangeInterface>
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function getActivityClass(): string {
+    return ContractChangeTypeContainer::getInstance()->getClassForActivityTypeId($this->change_activity_type_id);
   }
 
+  /**
+   * @throws \CRM_Core_Exception
+   */
   public function getActivityAction(): ?string {
     $class = $this->getActivityClass();
-    if (NULL === $class) {
-      throw new \RuntimeException('No class name resolved for activity type.');
-    }
-    return CRM_Contract_Change::getActionByClass($class);
+
+    return is_a($class, SchedulableContractChangeInterface::class, TRUE) ? $class::getActionName() : NULL;
   }
 
 }

--- a/Civi/Contract/Event/RenderChangeSubjectEvent.php
+++ b/Civi/Contract/Event/RenderChangeSubjectEvent.php
@@ -10,7 +10,8 @@ declare(strict_types = 1);
 
 namespace Civi\Contract\Event;
 
-use Civi;
+use Civi\Contract\ContractChange\ContractChangeInterface;
+use Civi\Contract\ContractChange\SchedulableContractChangeInterface;
 use CRM_Contract_ExtensionUtil as E;
 use CRM_Contract_CustomData as CRM_Contract_CustomData;
 
@@ -29,52 +30,31 @@ class RenderChangeSubjectEvent extends AbstractConfigurationEvent {
   public const EVENT_NAME = 'de.contract.renderchangesubject';
 
   /**
-   * @var string the action name
+   * @var string|null the raw contract data after
    */
-  protected $change_action;
-
-  /**
-   * @var array the raw contract data before
-   */
-  protected $contract_data_before;
-
-  /**
-   * @var array the raw contract data after
-   */
-  protected $contract_data_after;
-
-  /**
-   * @var array the data of the change object
-   */
-  protected $change_data;
-
-  /**
-   * @var string the raw contract data after
-   */
-  protected $subject;
+  protected ?string $subject = NULL;
 
   /**
    * Symfony event to allow customisation of a contract change event subject
    *
-   * @param string $change_action
-   *   the internal name of the change action
-   *
-   * @param array $contract_data_before
+   * @param array<string, mixed>|null $contract_data_before
    *   the state of the contract before the change
    *
-   * @param array $contract_data_after
+   * @param array<string, mixed>|null $contract_data_after
    *   the state of the contract after the change
    */
-  public function __construct($change_action, $contract_data_before, $contract_data_after) {
+  public function __construct(
+    private readonly ContractChangeInterface $change,
+    protected ?array $contract_data_before,
+    protected ?array $contract_data_after
+  ) {
     $this->subject = NULL;
-    $this->change_action = $change_action;
-    $this->change_data = NULL;
-    $this->contract_data_before = $contract_data_before;
-    $this->contract_data_after = $contract_data_after;
-    if ($this->contract_data_before) {
+    if (NULL !== $this->contract_data_before) {
+      // @phpstan-ignore assign.propertyType
       CRM_Contract_CustomData::labelCustomFields($this->contract_data_before);
     }
-    if ($this->contract_data_after) {
+    if (NULL !== $this->contract_data_after) {
+      // @phpstan-ignore assign.propertyType
       CRM_Contract_CustomData::labelCustomFields($this->contract_data_after);
     }
   }
@@ -82,22 +62,23 @@ class RenderChangeSubjectEvent extends AbstractConfigurationEvent {
   /**
    * Issue a Symfony event to render a contract change's subject/title
    *
-   * @param string $change_action
-   *   the internal name of the change action
-   *
-   * @param array|null $contract_data_before
+   * @param array<string, mixed>|null $contract_data_before
    *   the state of the contract before the change
    *
-   * @param array|null $contract_data_after
+   * @param array<string, mixed>|null $contract_data_after
    *   the state of the contract after the change
    *
-   * @return string
+   * @return string|null
    *   the subject line of the given change activity
    */
-  public static function renderCustomChangeSubject($change_action, $contract_data_before, $contract_data_after) {
+  public static function renderCustomChangeSubject(
+    ContractChangeInterface $change,
+    ?array $contract_data_before,
+    ?array $contract_data_after
+  ): ?string {
     // create and run event
-    $event = new RenderChangeSubjectEvent($change_action, $contract_data_before, $contract_data_after);
-    Civi::dispatcher()->dispatch(self::EVENT_NAME, $event);
+    $event = new RenderChangeSubjectEvent($change, $contract_data_before, $contract_data_after);
+    \Civi::dispatcher()->dispatch(self::EVENT_NAME, $event);
 
     $custom_subject = $event->getRenderedSubject();
     return $custom_subject;
@@ -109,17 +90,17 @@ class RenderChangeSubjectEvent extends AbstractConfigurationEvent {
    * @param string $subject
    *    the proposed subject for the change
    */
-  public function setRenderedSubject($subject) {
+  public function setRenderedSubject(string $subject): void {
     $this->subject = $subject;
   }
 
   /**
    * Get the currently proposed subject
    *
-   * @return string
+   * @return string|null
    *   the proposed subject for the change
    */
-  public function getRenderedSubject() {
+  public function getRenderedSubject(): ?string {
     return $this->subject;
   }
 
@@ -132,7 +113,7 @@ class RenderChangeSubjectEvent extends AbstractConfigurationEvent {
    * @return mixed
    *   raw contract data before the change
    */
-  public function getContractDataBefore($attribute = NULL) {
+  public function getContractDataBefore(?string $attribute = NULL): mixed {
     if ($attribute) {
       return $this->contract_data_before[$attribute] ?? NULL;
     }
@@ -150,7 +131,7 @@ class RenderChangeSubjectEvent extends AbstractConfigurationEvent {
    * @return mixed
    *   raw contract data after the change
    */
-  public function getContractDataAfter($attribute = NULL) {
+  public function getContractDataAfter(?string $attribute = NULL): mixed {
     if ($attribute) {
       return $this->contract_data_after[$attribute] ?? NULL;
     }
@@ -170,7 +151,7 @@ class RenderChangeSubjectEvent extends AbstractConfigurationEvent {
    * @return mixed|null
    *   the value
    */
-  public function getContractAttribute($attribute_name) {
+  public function getContractAttribute(string $attribute_name): mixed {
     return $this->contract_data_after[$attribute_name]
         ?? \CRM_Utils_Request::retrieve($attribute_name, 'String')
         ?? $this->contract_data_before[$attribute_name]
@@ -188,7 +169,7 @@ class RenderChangeSubjectEvent extends AbstractConfigurationEvent {
    * @return mixed|null
    *   the value
    */
-  public function getChangeAttribute($attribute_name) {
+  public function getChangeAttribute(string $attribute_name): mixed {
     // this is all mixed up in the same pile
     return $this->getContractAttribute($attribute_name);
   }
@@ -198,14 +179,18 @@ class RenderChangeSubjectEvent extends AbstractConfigurationEvent {
    *
    * @return string
    */
-  public function getActivityAction() {
-    return $this->change_action;
+  public function getActivityAction(): ?string {
+    return $this->change instanceof SchedulableContractChangeInterface ? $this->change::getActionName() : NULL;
+  }
+
+  public function getActivityTypeName(): string {
+    return $this->change::getActivityTypeName();
   }
 
   /**
    * @return string label of the membership type
    */
-  public function getMembershipTypeName() {
+  public function getMembershipTypeName(): string {
     $type_id = $this->getContractAttribute('membership_type_id');
     if (!empty($type_id)) {
       return \CRM_Contract_Utils::lookupValue('MembershipType', 'name', ['id' => $type_id]);
@@ -218,7 +203,7 @@ class RenderChangeSubjectEvent extends AbstractConfigurationEvent {
   /**
    * @return string label of the cancel reason
    */
-  public function getCancelReason() {
+  public function getCancelReason(): string {
     $reason_id = $this->getChangeAttribute('contract_cancellation.contact_history_cancel_reason');
     if (empty($reason_id)) {
       $reason_id = $this->getContractAttribute('membership_cancellation.membership_cancel_reason');
@@ -236,7 +221,7 @@ class RenderChangeSubjectEvent extends AbstractConfigurationEvent {
    *
    * @return float annual amount
    */
-  public function getMembershipAnnualAmount() {
+  public function getMembershipAnnualAmount(): float {
     $new_amount = (float) $this->getChangeAttribute('contract_updates.ch_annual');
     if (empty($new_amount)) {
       $new_amount = (float) $this->getContractAttribute('membership_payment.membership_annual');
@@ -247,7 +232,7 @@ class RenderChangeSubjectEvent extends AbstractConfigurationEvent {
   /**
    * @return float annual amount
    */
-  public function getMembershipIncreaseAmount() {
+  public function getMembershipIncreaseAmount(): float {
     $value = $this->getChangeAttribute('contract_updates.ch_annual_diff');
     if (!$value) {
       // no diff recorded, try to calculate
@@ -265,7 +250,7 @@ class RenderChangeSubjectEvent extends AbstractConfigurationEvent {
   /**
    * @return string rendered
    */
-  public function getExecutionDate($date_format = 'Y-m-d') {
+  public function getExecutionDate(): string {
     $date = $this->getChangeAttribute('activity_date_time');
     if ($date) {
       return date('Y-m-d', strtotime($date));
@@ -278,12 +263,13 @@ class RenderChangeSubjectEvent extends AbstractConfigurationEvent {
   /**
    * @return string label of the frequency
    */
-  public function getMembershipPaymentFrequency() {
+  public function getMembershipPaymentFrequency(): string {
     $frequency = (int) $this->getChangeAttribute('contract_updates.ch_frequency');
     if (empty($frequency)) {
       $frequency = (int) $this->getContractAttribute('membership_payment.membership_frequency');
     }
-    return \CRM_Contract_Utils::lookupOptionValue('payment_frequency', $frequency);
+    /** @var string */
+    return \CRM_Contract_Utils::lookupOptionValue('payment_frequency', (string) $frequency);
   }
 
 }

--- a/Civi/Contract/EventSubscriber/CivicrmLinksSubscriber.php
+++ b/Civi/Contract/EventSubscriber/CivicrmLinksSubscriber.php
@@ -1,0 +1,111 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Contract\EventSubscriber;
+
+use Civi\Api4\Membership;
+use Civi\Contract\ContractChange\ContractChangeTypeContainer;
+use Civi\Core\Event\GenericHookEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class CivicrmLinksSubscriber implements EventSubscriberInterface {
+
+  public static function getSubscribedEvents(): array {
+    return ['hook_civicrm_links' => 'modifyLinks'];
+  }
+
+  public function __construct(
+    private readonly ContractChangeTypeContainer $changeTypeContainer
+  ) {}
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function modifyLinks(GenericHookEvent $event): void {
+    $objectId = (int) $event->objectId;
+    /** @var array<int, array<string, mixed>> $links */
+    $links = &$event->links;
+    if ($event->objectName === 'Membership') {
+      // Custom links for memberships
+      if (0 !== $objectId) {
+        /** @var array<string, mixed> $membershipData */
+        $membershipData = Membership::get(FALSE)
+          ->addSelect('*', 'status_id:name')
+          ->addWhere('id', '=', $objectId)
+          ->execute()
+          ->single();
+
+        // alter links
+        $this->modifyMembershipLinks($membershipData, $links);
+      }
+    }
+    elseif ($event->op === 'contribution.selector.row') {
+      // add a Contract link to contributions that are connected to memberships
+      $contributionId = $objectId;
+      if (0 !== $contributionId) {
+        // add 'view contract' link
+        $membershipId = (int) \CRM_Core_DAO::singleValueQuery(
+          "SELECT membership_id FROM civicrm_membership_payment WHERE contribution_id = {$contributionId} LIMIT 1"
+        );
+        if (0 !== $membershipId) {
+          $contactId = (int) \CRM_Core_DAO::singleValueQuery(
+            "SELECT contact_id FROM civicrm_membership WHERE id = {$membershipId} LIMIT 1"
+          );
+          if (0 !== $contactId) {
+            $links[] = [
+              'name'  => 'Contract',
+              'title' => 'View Contract',
+              'url'   => 'civicrm/contact/view/membership',
+              'qs'    => "reset=1&id={$membershipId}&cid={$contactId}&action=view",
+            ];
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * @param array<string, mixed> $membershipData
+   * @param array<int, array<string, mixed>> $links
+   */
+  private function modifyMembershipLinks(array $membershipData, array &$links): void {
+    // first remove the default ones that shouldn't be used anymore
+    $obsolete_actions = [
+      \CRM_Core_Action::RENEW,
+      \CRM_Core_Action::FOLLOWUP,
+      \CRM_Core_Action::DELETE,
+      \CRM_Core_Action::UPDATE,
+    ];
+    foreach ($links as $key => $link) {
+      if (in_array($link['bit'], $obsolete_actions, TRUE)) {
+        unset($links[$key]);
+      }
+    }
+
+    // add the replacement actions
+    $statusName = $membershipData['status_id:name'];
+    foreach ($this->changeTypeContainer->getClassesByActivityType() as $change_class) {
+      if (method_exists($change_class, 'modifyMembershipActionLinks')) {
+        $change_class::modifyMembershipActionLinks($links, $statusName, $membershipData);
+      }
+    }
+  }
+
+}

--- a/Civi/Contract/SearchDisplayLinks.php
+++ b/Civi/Contract/SearchDisplayLinks.php
@@ -156,15 +156,31 @@ class SearchDisplayLinks implements EventSubscriberInterface {
    */
   private static function getActiveDisplayLinks(): array {
     return [
-      self::link('update', E::ts('Update Contract'), 'fa-pencil',
-        ['status_id:name', 'IN', \CRM_Contract_Change_Upgrade::getStartStatusList()]),
-      self::link('pause', E::ts('Pause Contract'), 'fa-pause',
-        ['status_id:name', 'IN', \CRM_Contract_Change_Pause::getStartStatusList()]),
-      self::link('resume', E::ts('Resume Contract'), 'fa-play',
-        ['status_id:name', 'IN', \CRM_Contract_Change_Resume::getStartStatusList()]),
-      self::link('cancel', E::ts('Cancel Contract'), 'fa-times',
+      self::link(
+        \CRM_Contract_Change_Update::getActionName(),
+        \CRM_Contract_Change_Update::getTitle(),
+        'fa-pencil',
+        ['status_id:name', 'IN', \CRM_Contract_Change_Update::getStartStatusList()]
+      ),
+      self::link(
+        \CRM_Contract_Change_Pause::getActionName(),
+        \CRM_Contract_Change_Pause::getTitle(),
+        'fa-pause',
+        ['status_id:name', 'IN', \CRM_Contract_Change_Pause::getStartStatusList()]
+      ),
+      self::link(
+        \CRM_Contract_Change_Resume::getActionName(),
+        \CRM_Contract_Change_Resume::getTitle(),
+        'fa-play',
+        ['status_id:name', 'IN', \CRM_Contract_Change_Resume::getStartStatusList()]
+      ),
+      self::link(
+        \CRM_Contract_Change_Cancel::getActionName(),
+        \CRM_Contract_Change_Cancel::getTitle(),
+        'fa-times',
         ['status_id:name', 'IN', \CRM_Contract_Change_Cancel::getStartStatusList()],
-        'danger'),
+        'danger'
+      ),
     ];
   }
 

--- a/api/v3/Contract/Create.php
+++ b/api/v3/Contract/Create.php
@@ -61,12 +61,11 @@ function civicrm_api3_Contract_create($params) {
   }
 
   // create 'sign' activity
-  $params['activity_type_id'] = 'sign';
-  $contractManager = new ContractManager();
+  $params['activity_type_id:name'] = CRM_Contract_Change_Sign::getActivityTypeName();
+  $contractManager = ContractManager::getInstance();
   $change = $contractManager->createContractChange(
     (int) $membership['id'],
-    $params,
-    'Completed'
+    $params
   );
 
   // also derive contract fields

--- a/api/v3/Contract/Modify.php
+++ b/api/v3/Contract/Modify.php
@@ -7,6 +7,9 @@
 +--------------------------------------------------------------*/
 
 declare(strict_types = 1);
+
+use Civi\Contract\ContractChange\ContractChangeTypeContainer;
+use Civi\Contract\ContractChange\SchedulableContractChangeInterface;
 use Civi\Contract\ContractManager;
 
 /**
@@ -50,7 +53,6 @@ function civicrm_api3_Contract_modify($params) {
     $params['date'] = 'now';
   }
 
-  // use activity_type_id instead of modify_action
   $params['action'] = $params['modify_action'];
 
   // also: revert REST-like '.' -> '_' conversion
@@ -73,7 +75,8 @@ function civicrm_api3_Contract_modify($params) {
   }
 
   // modify data to match internal structure
-  $params['activity_type_id'] = $params['action'];
+  $params['activity_type_id:name'] = ContractChangeTypeContainer::getInstance()
+    ->getClassForAction($params['action'])::getActivityTypeName();
   $params['activity_date_time'] = date('Y-m-d H:i:s', $requested_execution_time);
   $params['contract_activity.contract_id'] = (int) $params['id'];
   $params['source_record_id'] = (int) $params['id'];
@@ -83,11 +86,12 @@ function civicrm_api3_Contract_modify($params) {
   }
 
   // generate change (activity)
-  $contractManager = new ContractManager();
+  $contractManager = ContractManager::getInstance();
   $change = $contractManager->createContractChange(
     $params['contract_activity.contract_id'],
     $params
   );
+  assert($change instanceof SchedulableContractChangeInterface);
 
   // make sure any newly created conflicts are marked
   $change->checkForConflicts();

--- a/api/v3/Contract/ProcessScheduledModifications.php
+++ b/api/v3/Contract/ProcessScheduledModifications.php
@@ -8,6 +8,9 @@
 
 declare(strict_types = 1);
 
+use Civi\Contract\ContractChange\ContractChangeFactory;
+use Civi\Contract\ContractChange\ContractChangeTypeContainer;
+
 const CE_ENGINE_PROCESSING_LIMIT = 500;
 
 /**
@@ -72,7 +75,7 @@ function civicrm_api3_Contract_process_scheduled_modifications($params) {
       'contract_cancellation.*',
       'contract_updates.*',
     )
-    ->addWhere('activity_type_id', 'IN', CRM_Contract_Change::getActivityTypeIds())
+    ->addWhere('activity_type_id:name', 'IN', ContractChangeTypeContainer::getInstance()->getActivityTypes())
     ->addWhere('status_id:name', '=', 'Scheduled')
     // execute everything scheduled in the past
     ->addWhere('activity_date_time', '<=', date('Y-m-d H:i:s', strtotime($params['now'] ?? 'now')))
@@ -101,7 +104,7 @@ function civicrm_api3_Contract_process_scheduled_modifications($params) {
 
     // execute the changes
     // @phpstan-ignore argument.type
-    $change = CRM_Contract_Change::getChangeForData($scheduled_activity);
+    $change = ContractChangeFactory::getInstance()->createSchedulable($scheduled_activity);
     $result['order'][] = $change->getID();
     try {
       // verify the data before execution

--- a/contract.php
+++ b/contract.php
@@ -14,11 +14,17 @@ declare(strict_types = 1);
 require_once 'contract.civix.php';
 // phpcs:enable
 
+use Civi\Contract\ContractChange\ContractChangeFactory;
+use Civi\Contract\ContractChange\ContractChangeTypeContainer;
+use Civi\Contract\ContractChange\ContractChangeInterface;
+use Civi\Contract\EventSubscriber\CivicrmLinksSubscriber;
+use Civi\Core\ClassScanner;
 use CRM_Contract_ExtensionUtil as E;
 use Civi\Contract\ContractManager;
 use Civi\Contract\Api4\Action\Contract\AddRelatedMembershipAction;
 use Civi\Contract\Api4\Action\Contract\EndRelatedMembershipAction;
 use Civi\Contract\SearchDisplayLinks;
+use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -27,17 +33,29 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_container/
  */
 function contract_civicrm_container(ContainerBuilder $container): void {
+  $container->addResource(new FileResource(__FILE__));
+
   if (class_exists('\Civi\Contract\ContainerSpecs')) {
     $container->addCompilerPass(new \Civi\Contract\ContainerSpecs());
   }
 
-  $container->autowire(ContractManager::class);
+  $container->autowire(ContractManager::class)
+    ->setPublic(TRUE);
   $container
     ->autowire(AddRelatedMembershipAction::class)
     ->setPublic(TRUE);
   $container
     ->autowire(EndRelatedMembershipAction::class)
     ->setPublic(TRUE);
+
+  $container->register(ContractChangeTypeContainer::class)->addArgument(
+    ClassScanner::get(['interface' => ContractChangeInterface::class])
+  )->setPublic(TRUE);
+  $container->autowire(ContractChangeFactory::class)
+    ->setPublic(TRUE);
+
+  $container->autowire(CivicrmLinksSubscriber::class)
+    ->addTag('kernel.event_subscriber');
 }
 
 /**
@@ -79,7 +97,7 @@ function contract_civicrm_pageRun(CRM_Core_Page &$page): void {
     /** @var CRM_Contact_Page_View_Summary $page */
     // this is the contact summary page
     Civi::resources()
-      ->addVars('contract', ['ce_activity_types' => CRM_Contract_Change::getActivityTypeIds()])
+      ->addVars('contract', ['ce_activity_types' => ContractChangeTypeContainer::getInstance()->getActivityTypeIds()])
       ->addScriptUrl(E::url('js/hide-ce-activity-types.js'));
 
   }
@@ -277,42 +295,6 @@ function contract_civicrm_validateForm($formName, &$fields, &$files, &$form, &$e
 /**
  * Implements hook_civicrm_links().
  */
-function contract_civicrm_links($op, $objectName, $objectId, &$links, &$mask, &$values) {
-  // Custom links for memberships
-  if ($objectName == 'Membership') {
-    if ($objectId) {
-      // load membership
-      $membership_data = civicrm_api3('Membership', 'getsingle', ['id' => $objectId]);
-
-      // alter links
-      CRM_Contract_Change::modifyActionLinks($membership_data, $links);
-    }
-
-  }
-  elseif ($op == 'contribution.selector.row') {
-    // add a Contract link to contributions that are connected to memberships
-    $contribution_id = (int) $objectId;
-    if ($contribution_id) {
-      // add 'view contract' link
-      $membership_id = CRM_Core_DAO::singleValueQuery(
-        "SELECT membership_id FROM civicrm_membership_payment WHERE contribution_id = {$contribution_id} LIMIT 1"
-      );
-      if ($membership_id) {
-        $contact_id = CRM_Core_DAO::singleValueQuery(
-          "SELECT contact_id FROM civicrm_membership WHERE id = {$membership_id} LIMIT 1"
-        );
-        if ($contact_id) {
-          $links[] = [
-            'name'  => 'Contract',
-            'title' => 'View Contract',
-            'url'   => 'civicrm/contact/view/membership',
-            'qs'    => "reset=1&id={$membership_id}&cid={$contact_id}&action=view",
-          ];
-        }
-      }
-    }
-  }
-}
 
 /**
  * Implements hook_civicrm_navigationMenu().
@@ -389,5 +371,5 @@ function contract_civicrm_permission(&$permissions) {
  */
 function contract_civicrm_scanClasses(array &$classes): void {
   // @phpstan-ignore parameterByRef.type
-  \Civi\Core\ClassScanner::scanFolders($classes, __DIR__, 'Civi/ActionProvider/Action', '\\');
+  ClassScanner::scanFolders($classes, __DIR__, 'CRM/Contract/Change', '_');
 }

--- a/managed/10-OptionGroup_activity_type.mgd.php
+++ b/managed/10-OptionGroup_activity_type.mgd.php
@@ -17,11 +17,12 @@
 
 declare(strict_types = 1);
 
-use CRM_Contract_ExtensionUtil as E;
+use Civi\Contract\ContractChange\ContractChangeTypeContainer;
 
-return [
-  [
-    'name' => 'OptionGroup_activity_type_OptionValue_Contract_Signed',
+$activityTypes = [];
+foreach (ContractChangeTypeContainer::getInstance()->getClassesByActivityType() as $class) {
+  $activityTypes[] = [
+    'name' => 'OptionGroup_activity_type_OptionValue_' . $class::getActivityTypeName(),
     'entity' => 'OptionValue',
     'cleanup' => 'unused',
     'update' => 'unmodified',
@@ -29,184 +30,18 @@ return [
       'version' => 4,
       'values' => [
         'option_group_id.name' => 'activity_type',
-        'label' => E::ts('Sign Contract'),
-        'name' => 'Contract_Signed',
+        'label' => $class::getTitle(),
+        'name' => $class::getActivityTypeName(),
         'filter' => 1,
         'is_reserved' => TRUE,
-        'icon' => 'fa-dot-circle-o',
+        'icon' => $class::getActivityTypeIcon(),
       ],
       'match' => [
         'option_group_id',
         'name',
       ],
     ],
-  ],
-  [
-    'name' => 'OptionGroup_activity_type_OptionValue_Contract_Paused',
-    'entity' => 'OptionValue',
-    'cleanup' => 'unused',
-    'update' => 'unmodified',
-    'params' => [
-      'version' => 4,
-      'values' => [
-        'option_group_id.name' => 'activity_type',
-        'label' => E::ts('Pause Contract'),
-        'name' => 'Contract_Paused',
-        'filter' => 1,
-        'is_reserved' => TRUE,
-        'icon' => 'fa-pause-circle-o',
-      ],
-      'match' => [
-        'option_group_id',
-        'name',
-      ],
-    ],
-  ],
-  [
-    'name' => 'OptionGroup_activity_type_OptionValue_Contract_Resumed',
-    'entity' => 'OptionValue',
-    'cleanup' => 'unused',
-    'update' => 'unmodified',
-    'params' => [
-      'version' => 4,
-      'values' => [
-        'option_group_id.name' => 'activity_type',
-        'label' => E::ts('Resume Contract'),
-        'name' => 'Contract_Resumed',
-        'filter' => 1,
-        'is_reserved' => TRUE,
-        'icon' => 'fa-play-circle-o',
-      ],
-      'match' => [
-        'option_group_id',
-        'name',
-      ],
-    ],
-  ],
-  [
-    'name' => 'OptionGroup_activity_type_OptionValue_Contract_Updated',
-    'entity' => 'OptionValue',
-    'cleanup' => 'unused',
-    'update' => 'unmodified',
-    'params' => [
-      'version' => 4,
-      'values' => [
-        'option_group_id.name' => 'activity_type',
-        'label' => E::ts('Update Contract'),
-        'name' => 'Contract_Updated',
-        'filter' => 1,
-        'is_reserved' => TRUE,
-        'icon' => 'fa-arrow-circle-o-up',
-      ],
-      'match' => [
-        'option_group_id',
-        'name',
-      ],
-    ],
-  ],
-  [
-    'name' => 'OptionGroup_activity_type_OptionValue_Contract_Cancelled',
-    'entity' => 'OptionValue',
-    'cleanup' => 'unused',
-    'update' => 'unmodified',
-    'params' => [
-      'version' => 4,
-      'values' => [
-        'option_group_id.name' => 'activity_type',
-        'label' => E::ts('Cancel Contract'),
-        'name' => 'Contract_Cancelled',
-        'filter' => 1,
-        'is_reserved' => TRUE,
-        'icon' => 'fa-stop-circle-o',
-      ],
-      'match' => [
-        'option_group_id',
-        'name',
-      ],
-    ],
-  ],
-  [
-    'name' => 'OptionGroup_activity_type_OptionValue_Contract_Revived',
-    'entity' => 'OptionValue',
-    'cleanup' => 'unused',
-    'update' => 'unmodified',
-    'params' => [
-      'version' => 4,
-      'values' => [
-        'option_group_id.name' => 'activity_type',
-        'label' => E::ts('Revive Contract'),
-        'name' => 'Contract_Revived',
-        'filter' => 1,
-        'is_reserved' => TRUE,
-        'icon' => 'fa-play-circle-o',
-      ],
-      'match' => [
-        'option_group_id',
-        'name',
-      ],
-    ],
-  ],
-  [
-    'name' => 'OptionGroup_activity_type_OptionValue_Secondary_Membership_Created',
-    'entity' => 'OptionValue',
-    'cleanup' => 'unused',
-    'update' => 'unmodified',
-    'params' => [
-      'version' => 4,
-      'values' => [
-        'option_group_id.name' => 'activity_type',
-        'label' => E::ts('Create Secondary Membership'),
-        'name' => 'Secondary_Membership_Created',
-        'filter' => 1,
-        'is_reserved' => TRUE,
-        'icon' => 'fa-person-circle-plus',
-      ],
-      'match' => [
-        'option_group_id',
-        'name',
-      ],
-    ],
-  ],
-  [
-    'name' => 'OptionGroup_activity_type_OptionValue_Secondary_Membership_Ended',
-    'entity' => 'OptionValue',
-    'cleanup' => 'unused',
-    'update' => 'unmodified',
-    'params' => [
-      'version' => 4,
-      'values' => [
-        'option_group_id.name' => 'activity_type',
-        'label' => E::ts('End Secondary Membership'),
-        'name' => 'Secondary_Membership_Ended',
-        'filter' => 1,
-        'is_reserved' => TRUE,
-        'icon' => 'fa-person-circle-minus',
-      ],
-      'match' => [
-        'option_group_id',
-        'name',
-      ],
-    ],
-  ],
-  [
-    'name' => 'OptionGroup_activity_type_OptionValue_Secondary_Membership_Updated',
-    'entity' => 'OptionValue',
-    'cleanup' => 'unused',
-    'update' => 'unmodified',
-    'params' => [
-      'version' => 4,
-      'values' => [
-        'option_group_id.name' => 'activity_type',
-        'label' => E::ts('Update Secondary Membership'),
-        'name' => 'Secondary_Membership_Updated',
-        'filter' => 1,
-        'is_reserved' => TRUE,
-        'icon' => 'fa-person-circle-exclamation',
-      ],
-      'match' => [
-        'option_group_id',
-        'name',
-      ],
-    ],
-  ],
-];
+  ];
+}
+
+return $activityTypes;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -300,12 +300,6 @@ parameters:
 			path: CRM/Contract/BankingLogic.php
 
 		-
-			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
-			identifier: function.strict
-			count: 2
-			path: CRM/Contract/Change.php
-
-		-
 			message: '#^Cannot cast mixed to int\.$#'
 			identifier: cast.int
 			count: 1
@@ -314,137 +308,11 @@ parameters:
 		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
-			count: 8
+			count: 5
 			path: CRM/Contract/Change.php
 
 		-
 			message: '#^In method "CRM_Contract_Change\:\:derivePaymentData", caught "Exception" must be rethrown\. Either catch a more specific exception, add a "throw" clause in the "catch" block to propagate the exception or add a "// @ignoreException" comment\.$#'
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:checkForConflicts\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:convertContract2ChangeData\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:convertContract2ChangeData\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:convertContract2ChangeData\(\) has parameter \$reverse with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:derivePaymentData\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:derivePaymentData\(\) has parameter \$contract with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:getActionLabels\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:getActionName\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:getActivityIdForClass\(\) should return int but returns int\|string\|null\.$#'
-			identifier: return.type
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:getActivityTypeId2Class\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:getActivityTypeIds\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:getChangeTypes\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:getClassByAction\(\) has parameter \$action with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:getClassByAction\(\) should return string but returns string\|null\.$#'
-			identifier: return.type
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:getContract\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:getContract\(\) should return array but returns array\|null\.$#'
-			identifier: return.type
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:getCustomFieldList\(\) should return list\<string\> but returns list\<mixed\>\.$#'
-			identifier: return.type
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:getID\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:getSubject\(\) has parameter \$contract_after with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:getSubject\(\) has parameter \$contract_before with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:isNew\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: CRM/Contract/Change.php
 
@@ -485,48 +353,6 @@ parameters:
 			path: CRM/Contract/Change.php
 
 		-
-			message: '#^Method CRM_Contract_Change\:\:modifyActionLinks\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:modifyActionLinks\(\) has parameter \$links with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:modifyActionLinks\(\) has parameter \$membership_data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:populateData\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:renderChangeSubject\(\) has parameter \$change with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:renderChangeSubject\(\) has parameter \$contract_after with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:renderChangeSubject\(\) has parameter \$contract_before with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
 			message: '#^Method CRM_Contract_Change\:\:resolveValue\(\) has parameter \$field_name with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -551,166 +377,16 @@ parameters:
 			path: CRM/Contract/Change.php
 
 		-
-			message: '#^Method CRM_Contract_Change\:\:save\(\) has no return type specified\.$#'
-			identifier: missingType.return
+			message: '#^Part \$contract\[''membership_payment\.membership_recurring_contribution''\] \(mixed\) of encapsed string cannot be cast to string\.$#'
+			identifier: encapsedStringPart.nonString
 			count: 1
 			path: CRM/Contract/Change.php
 
 		-
-			message: '#^Method CRM_Contract_Change\:\:setParameter\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:shouldBeAccepted\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:updateContract\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:updateContract\(\) has parameter \$updates with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:verifyData\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Method CRM_Contract_Change\:\:verifyStatusChange\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Property CRM_Contract_Change\:\:\$_type_id2label type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Static call to instance method stdClass\:\:modifyMembershipActionLinks\(\)\.$#'
-			identifier: method.staticCall
-			count: 1
-			path: CRM/Contract/Change.php
-
-		-
-			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
-			identifier: function.strict
+			message: '#^Cannot cast mixed to int\.$#'
+			identifier: cast.int
 			count: 1
 			path: CRM/Contract/Change/Cancel.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Cancel\:\:getStartStatusList\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: CRM/Contract/Change/Cancel.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Cancel\:\:modifyMembershipActionLinks\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change/Cancel.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Cancel\:\:modifyMembershipActionLinks\(\) has parameter \$current_status_name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Change/Cancel.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Cancel\:\:modifyMembershipActionLinks\(\) has parameter \$links with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Change/Cancel.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Cancel\:\:modifyMembershipActionLinks\(\) has parameter \$membership_data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Change/Cancel.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Cancel\:\:populateData\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change/Cancel.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Cancel\:\:shouldBeAccepted\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change/Cancel.php
-
-		-
-			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
-			identifier: function.strict
-			count: 1
-			path: CRM/Contract/Change/Pause.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Pause\:\:getStartStatusList\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: CRM/Contract/Change/Pause.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Pause\:\:modifyMembershipActionLinks\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change/Pause.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Pause\:\:modifyMembershipActionLinks\(\) has parameter \$current_status_name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Change/Pause.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Pause\:\:modifyMembershipActionLinks\(\) has parameter \$links with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Change/Pause.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Pause\:\:modifyMembershipActionLinks\(\) has parameter \$membership_data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Change/Pause.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Pause\:\:populateData\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change/Pause.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Pause\:\:save\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change/Pause.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Pause\:\:shouldBeAccepted\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change/Pause.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Pause\:\:verifyData\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change/Pause.php
 
 		-
 			message: '#^Only booleans are allowed in a negated boolean, mixed given\.$#'
@@ -749,63 +425,9 @@ parameters:
 			path: CRM/Contract/Change/Pause.php
 
 		-
-			message: '#^Method CRM_Contract_Change_Resume\:\:getStartStatusList\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: CRM/Contract/Change/Resume.php
-
-		-
-			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
-			identifier: function.strict
-			count: 1
-			path: CRM/Contract/Change/Revive.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Revive\:\:getStartStatusList\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: CRM/Contract/Change/Revive.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Revive\:\:modifyMembershipActionLinks\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change/Revive.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Revive\:\:updateContract\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change/Revive.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Revive\:\:updateContract\(\) has parameter \$updates with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Contract/Change/Revive.php
-
-		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
 			count: 4
-			path: CRM/Contract/Change/Sign.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Sign\:\:getStartStatusList\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: CRM/Contract/Change/Sign.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Sign\:\:populateData\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change/Sign.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Sign\:\:shouldBeAccepted\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
 			path: CRM/Contract/Change/Sign.php
 
 		-
@@ -821,160 +443,148 @@ parameters:
 			path: CRM/Contract/Change/Sign.php
 
 		-
-			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
-			identifier: function.strict
-			count: 1
-			path: CRM/Contract/Change/Upgrade.php
-
-		-
 			message: '#^Cannot cast mixed to int\.$#'
 			identifier: cast.int
 			count: 2
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
 			count: 5
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
 			message: '#^Identical\: Possible insane comparison between null and non\-empty\-string\.$#'
 			identifier: voku.Identical
 			count: 2
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
 			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
 			identifier: notEqual.notAllowed
 			count: 1
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
-			message: '#^Method CRM_Contract_Change_Upgrade\:\:assignExistingRecurringContribution\(\) has no return type specified\.$#'
+			message: '#^Method CRM_Contract_Change_UpdateBase\:\:assignExistingRecurringContribution\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
-			message: '#^Method CRM_Contract_Change_Upgrade\:\:assignExistingRecurringContribution\(\) has parameter \$contract_before with no type specified\.$#'
+			message: '#^Method CRM_Contract_Change_UpdateBase\:\:assignExistingRecurringContribution\(\) has parameter \$contract_before with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
-			message: '#^Method CRM_Contract_Change_Upgrade\:\:assignExistingRecurringContribution\(\) has parameter \$to with no type specified\.$#'
+			message: '#^Method CRM_Contract_Change_UpdateBase\:\:assignExistingRecurringContribution\(\) has parameter \$to with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
-			message: '#^Method CRM_Contract_Change_Upgrade\:\:createNonSepaRecurring\(\) has no return type specified\.$#'
+			message: '#^Method CRM_Contract_Change_UpdateBase\:\:createNonSepaRecurring\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
-			message: '#^Method CRM_Contract_Change_Upgrade\:\:createNonSepaRecurring\(\) has parameter \$amount with no type specified\.$#'
+			message: '#^Method CRM_Contract_Change_UpdateBase\:\:createNonSepaRecurring\(\) has parameter \$amount with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
-			message: '#^Method CRM_Contract_Change_Upgrade\:\:createNonSepaRecurring\(\) has parameter \$contract with no type specified\.$#'
+			message: '#^Method CRM_Contract_Change_UpdateBase\:\:createNonSepaRecurring\(\) has parameter \$contract with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
-			message: '#^Method CRM_Contract_Change_Upgrade\:\:createNonSepaRecurring\(\) has parameter \$paymentInstrumentIdOrName with no type specified\.$#'
+			message: '#^Method CRM_Contract_Change_UpdateBase\:\:createNonSepaRecurring\(\) has parameter \$paymentInstrumentIdOrName with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
-			message: '#^Method CRM_Contract_Change_Upgrade\:\:createNonSepaRecurring\(\) has parameter \$payment_types with no type specified\.$#'
+			message: '#^Method CRM_Contract_Change_UpdateBase\:\:createNonSepaRecurring\(\) has parameter \$payment_types with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
-			message: '#^Method CRM_Contract_Change_Upgrade\:\:createSepaMandate\(\) has no return type specified\.$#'
+			message: '#^Method CRM_Contract_Change_UpdateBase\:\:createSepaMandate\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
-			message: '#^Method CRM_Contract_Change_Upgrade\:\:createSepaMandate\(\) has parameter \$contract with no type specified\.$#'
+			message: '#^Method CRM_Contract_Change_UpdateBase\:\:createSepaMandate\(\) has parameter \$contract with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
-			message: '#^Method CRM_Contract_Change_Upgrade\:\:createSepaMandate\(\) has parameter \$paymentInstrumentId with no type specified\.$#'
+			message: '#^Method CRM_Contract_Change_UpdateBase\:\:createSepaMandate\(\) has parameter \$paymentInstrumentId with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
-			message: '#^Method CRM_Contract_Change_Upgrade\:\:createSepaMandate\(\) has parameter \$payment_types with no type specified\.$#'
+			message: '#^Method CRM_Contract_Change_UpdateBase\:\:createSepaMandate\(\) has parameter \$payment_types with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
-			message: '#^Method CRM_Contract_Change_Upgrade\:\:getStartStatusList\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: CRM/Contract/Change/Upgrade.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Upgrade\:\:modifyMembershipActionLinks\(\) has no return type specified\.$#'
+			message: '#^Method CRM_Contract_Change_UpdateBase\:\:terminateSepaMandate\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
-			message: '#^Method CRM_Contract_Change_Upgrade\:\:terminateSepaMandate\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Contract/Change/Upgrade.php
-
-		-
-			message: '#^Method CRM_Contract_Change_Upgrade\:\:terminateSepaMandate\(\) has parameter \$contract with no type specified\.$#'
+			message: '#^Method CRM_Contract_Change_UpdateBase\:\:terminateSepaMandate\(\) has parameter \$contract with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
 			message: '#^Only booleans are allowed in a negated boolean, int given\.$#'
 			identifier: booleanNot.exprNotBoolean
 			count: 1
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
 			message: '#^Only booleans are allowed in a ternary operator condition, int\<1, max\> given\.$#'
 			identifier: ternary.condNotBoolean
 			count: 2
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
+
+		-
+			message: '#^Parameter \#1 \$id of method CRM_Contract_Change_UpdateBase\:\:classifyPaymentInstrument\(\) expects int\|string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
 			message: '#^Parameter \#5 \$paymentOption of static method CRM_Contract_RecurringContribution\:\:createRecurringContribution\(\) expects string, int\|string given\.$#'
 			identifier: argument.type
 			count: 1
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
 			message: '#^Parameter \#7 \$frequencyInterval of static method CRM_Contract_RecurringContribution\:\:createRecurringContribution\(\) expects int, float\|int\<1, 12\> given\.$#'
 			identifier: argument.type
 			count: 1
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
 			message: '#^Ternary operator condition is always true\.$#'
 			identifier: ternary.alwaysTrue
 			count: 2
-			path: CRM/Contract/Change/Upgrade.php
+			path: CRM/Contract/Change/UpdateBase.php
 
 		-
 			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
@@ -1171,7 +781,7 @@ parameters:
 		-
 			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
 			identifier: function.strict
-			count: 2
+			count: 1
 			path: CRM/Contract/Form/Modify.php
 
 		-
@@ -1181,15 +791,9 @@ parameters:
 			path: CRM/Contract/Form/Modify.php
 
 		-
-			message: '#^Cannot call static method getChangeTitle\(\) on string\|null\.$#'
-			identifier: staticMethod.nonObject
-			count: 1
-			path: CRM/Contract/Form/Modify.php
-
-		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
-			count: 16
+			count: 15
 			path: CRM/Contract/Form/Modify.php
 
 		-
@@ -1930,12 +1534,6 @@ parameters:
 		-
 			message: '#^Cannot access offset mixed on array\|int\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: CRM/Contract/Page/Review.php
-
-		-
-			message: '#^Method CRM_Contract_Page_Review\:\:run\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: CRM/Contract/Page/Review.php
 
@@ -3010,9 +2608,27 @@ parameters:
 			path: CRM/Contract/Validation/ContractNumber.php
 
 		-
+			message: '#^Call to method setCheckPermissions\(\) on an unknown class Civi\\Contract\\Api4\\Action\\Contract\\SuspendPaymentAction\.$#'
+			identifier: class.notFound
+			count: 1
+			path: Civi/Api4/Contract.php
+
+		-
 			message: '#^Cannot call method setCheckPermissions\(\) on mixed\.$#'
 			identifier: method.nonObject
 			count: 2
+			path: Civi/Api4/Contract.php
+
+		-
+			message: '#^Instantiated class Civi\\Contract\\Api4\\Action\\Contract\\SuspendPaymentAction not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: Civi/Api4/Contract.php
+
+		-
+			message: '#^Method Civi\\Api4\\Contract\:\:suspendPayment\(\) has invalid return type Civi\\Contract\\Api4\\Action\\Contract\\SuspendPaymentAction\.$#'
+			identifier: class.notFound
+			count: 1
 			path: Civi/Api4/Contract.php
 
 		-
@@ -3320,12 +2936,6 @@ parameters:
 			path: Civi/Contract/ActionProvider/Action/UpdateContract.php
 
 		-
-			message: '#^Method Civi\\Contract\\ActionProvider\\Action\\UpdateContract\:\:getModifyActions\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: Civi/Contract/ActionProvider/Action/UpdateContract.php
-
-		-
 			message: '#^Method Civi\\Contract\\ActionProvider\\Action\\UpdateContract\:\:yesNoOptions\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -3470,54 +3080,6 @@ parameters:
 			path: Civi/Contract/Event/DisplayChangeTitle.php
 
 		-
-			message: '#^Method Civi\\Contract\\Event\\DisplayChangeTitle\:\:renderDisplayChangeTitleAndHoverText\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: Civi/Contract/Event/DisplayChangeTitle.php
-
-		-
-			message: '#^Method Civi\\Contract\\Event\\DisplayChangeTitle\:\:setDisplayHoverTitle\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: Civi/Contract/Event/DisplayChangeTitle.php
-
-		-
-			message: '#^Method Civi\\Contract\\Event\\DisplayChangeTitle\:\:setDisplayHoverTitle\(\) has parameter \$title with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: Civi/Contract/Event/DisplayChangeTitle.php
-
-		-
-			message: '#^Method Civi\\Contract\\Event\\DisplayChangeTitle\:\:setDisplayTitle\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: Civi/Contract/Event/DisplayChangeTitle.php
-
-		-
-			message: '#^Method Civi\\Contract\\Event\\DisplayChangeTitle\:\:setDisplayTitle\(\) has parameter \$title with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: Civi/Contract/Event/DisplayChangeTitle.php
-
-		-
-			message: '#^PHPDoc tag @return has invalid value \(DisplayChangeTitle;\)\: Unexpected token ";", expected TOKEN_HORIZONTAL_WS at offset 274 on line 10$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: Civi/Contract/Event/DisplayChangeTitle.php
-
-		-
-			message: '#^Parameter \#1 \$data of static method CRM_Contract_CustomData\:\:labelCustomFields\(\) expects array\<int\|string, mixed\>, array\|int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: Civi/Contract/Event/DisplayChangeTitle.php
-
-		-
-			message: '#^Property Civi\\Contract\\Event\\DisplayChangeTitle\:\:\$change_activity_data \(array\) does not accept array\|int\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: Civi/Contract/Event/DisplayChangeTitle.php
-
-		-
 			message: '#^Property Civi\\Contract\\Event\\DisplayChangeTitle\:\:\$change_activity_data type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -3608,31 +3170,7 @@ parameters:
 			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
 
 		-
-			message: '#^Method Civi\\Contract\\Event\\RenderChangeSubjectEvent\:\:__construct\(\) has parameter \$contract_data_after with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
-
-		-
-			message: '#^Method Civi\\Contract\\Event\\RenderChangeSubjectEvent\:\:__construct\(\) has parameter \$contract_data_before with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
-
-		-
 			message: '#^Method Civi\\Contract\\Event\\RenderChangeSubjectEvent\:\:getCancelReason\(\) should return string but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
-
-		-
-			message: '#^Method Civi\\Contract\\Event\\RenderChangeSubjectEvent\:\:getExecutionDate\(\) has parameter \$date_format with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
-
-		-
-			message: '#^Method Civi\\Contract\\Event\\RenderChangeSubjectEvent\:\:getMembershipPaymentFrequency\(\) should return string but returns mixed\.$#'
 			identifier: return.type
 			count: 1
 			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
@@ -3644,33 +3182,9 @@ parameters:
 			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
 
 		-
-			message: '#^Method Civi\\Contract\\Event\\RenderChangeSubjectEvent\:\:renderCustomChangeSubject\(\) has parameter \$contract_data_after with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
-
-		-
-			message: '#^Method Civi\\Contract\\Event\\RenderChangeSubjectEvent\:\:renderCustomChangeSubject\(\) has parameter \$contract_data_before with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
-
-		-
-			message: '#^Method Civi\\Contract\\Event\\RenderChangeSubjectEvent\:\:setRenderedSubject\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
-
-		-
 			message: '#^Only booleans are allowed in a negated boolean, mixed given\.$#'
 			identifier: booleanNot.exprNotBoolean
 			count: 1
-			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
-
-		-
-			message: '#^Only booleans are allowed in an if condition, array given\.$#'
-			identifier: if.condNotBoolean
-			count: 2
 			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
 
 		-
@@ -3692,56 +3206,8 @@ parameters:
 			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
 
 		-
-			message: '#^Parameter \#2 \$contract_data_before of class Civi\\Contract\\Event\\RenderChangeSubjectEvent constructor expects array, array\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
-
-		-
-			message: '#^Parameter \#2 \$value of static method CRM_Contract_Utils\:\:lookupOptionValue\(\) expects string, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
-
-		-
 			message: '#^Parameter \#2 \$value of static method CRM_Contract_Utils\:\:lookupOptionValue\(\) expects string, mixed given\.$#'
 			identifier: argument.type
-			count: 1
-			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
-
-		-
-			message: '#^Parameter \#3 \$contract_data_after of class Civi\\Contract\\Event\\RenderChangeSubjectEvent constructor expects array, array\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
-
-		-
-			message: '#^Property Civi\\Contract\\Event\\RenderChangeSubjectEvent\:\:\$change_data \(array\) does not accept null\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
-
-		-
-			message: '#^Property Civi\\Contract\\Event\\RenderChangeSubjectEvent\:\:\$change_data type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
-
-		-
-			message: '#^Property Civi\\Contract\\Event\\RenderChangeSubjectEvent\:\:\$contract_data_after type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
-
-		-
-			message: '#^Property Civi\\Contract\\Event\\RenderChangeSubjectEvent\:\:\$contract_data_before type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
-
-		-
-			message: '#^Property Civi\\Contract\\Event\\RenderChangeSubjectEvent\:\:\$subject \(string\) does not accept null\.$#'
-			identifier: assign.propertyType
 			count: 1
 			path: Civi/Contract/Event/RenderChangeSubjectEvent.php
 
@@ -3962,6 +3428,12 @@ parameters:
 			path: api/v3/Contract/Modify.php
 
 		-
+			message: '#^Possibly invalid array key type mixed\.$#'
+			identifier: array.invalidKey
+			count: 1
+			path: api/v3/Contract/Modify.php
+
+		-
 			message: '#^Call to CRM_Contract_Configuration\:\:disableMonitoring\(\) on a separate line has no effect\.$#'
 			identifier: staticMethod.resultUnused
 			count: 1
@@ -4135,48 +3607,6 @@ parameters:
 			path: contract.php
 
 		-
-			message: '#^Function contract_civicrm_links\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: contract.php
-
-		-
-			message: '#^Function contract_civicrm_links\(\) has parameter \$links with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: contract.php
-
-		-
-			message: '#^Function contract_civicrm_links\(\) has parameter \$mask with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: contract.php
-
-		-
-			message: '#^Function contract_civicrm_links\(\) has parameter \$objectId with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: contract.php
-
-		-
-			message: '#^Function contract_civicrm_links\(\) has parameter \$objectName with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: contract.php
-
-		-
-			message: '#^Function contract_civicrm_links\(\) has parameter \$op with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: contract.php
-
-		-
-			message: '#^Function contract_civicrm_links\(\) has parameter \$values with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: contract.php
-
-		-
 			message: '#^Function contract_civicrm_navigationMenu\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -4251,25 +3681,13 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 11
-			path: contract.php
-
-		-
-			message: '#^Only booleans are allowed in an if condition, int given\.$#'
-			identifier: if.condNotBoolean
-			count: 1
+			count: 9
 			path: contract.php
 
 		-
 			message: '#^Only booleans are allowed in an if condition, mixed given\.$#'
 			identifier: if.condNotBoolean
 			count: 1
-			path: contract.php
-
-		-
-			message: '#^Only booleans are allowed in an if condition, string\|null given\.$#'
-			identifier: if.condNotBoolean
-			count: 2
 			path: contract.php
 
 		-

--- a/tests/phpunit/CRM/Contract/BugFollowupTest.php
+++ b/tests/phpunit/CRM/Contract/BugFollowupTest.php
@@ -10,6 +10,8 @@
 
 declare(strict_types = 1);
 
+use Civi\Contract\ContractChange\ContractChangeTypeContainer;
+
 /**
  * Bug reproduction and follow-up tests
  *
@@ -206,7 +208,8 @@ class CRM_Contract_BugFollowUpTest extends CRM_Contract_ContractTestBase {
     $this->modifyContract($contract['id'], 'update', 'now', [
       'membership_payment.membership_annual' => '480.00',
     ]);
-    $upgrade_change_type = CRM_Contract_Change::getActivityIdForClass('CRM_Contract_Change_Upgrade');
+    $upgrade_change_type = ContractChangeTypeContainer::getInstance()
+      ->getActivityTypeId(CRM_Contract_Change_Update::getActivityTypeName());
     $change_activity = $this->getLastChangeActivity($contract['id'], [$upgrade_change_type]);
 
     // reload contract

--- a/tests/phpunit/CRM/Contract/Change/UpdateTest.php
+++ b/tests/phpunit/CRM/Contract/Change/UpdateTest.php
@@ -20,9 +20,9 @@ declare(strict_types = 1);
 /**
  * @group headless
  *
- * @covers \CRM_Contract_Change_Upgrade
+ * @covers \CRM_Contract_Change_Update
  */
-class CRM_Contract_Change_UpgradeTest extends CRM_Contract_ContractTestBase {
+class CRM_Contract_Change_UpdateTest extends CRM_Contract_ContractTestBase {
 
   public function testExecute_WithIncreaseAcrossThousands_StoresCorrectDiff(): void {
     $contract = $this->createNewContract(['is_sepa' => 1, 'amount' => '96.00']);

--- a/tests/phpunit/CRM/Contract/CustomisationTest.php
+++ b/tests/phpunit/CRM/Contract/CustomisationTest.php
@@ -35,7 +35,7 @@ class CRM_Contract_CustomisationTest extends CRM_Contract_ContractTestBase {
   public function testRenderSubjectCustomisation(): void {
     $contract = $this->createNewContract(['is_sepa' => 1]);
     $last_change = $this->getLastChangeActivity($contract['id']);
-    static::assertEquals('TEST-sign', $last_change['subject'], 'The customisation hook failed.');
+    static::assertEquals('TEST-Contract_Signed', $last_change['subject'], 'The customisation hook failed.');
 
     // cancel contract
     $this->modifyContract($contract['id'], 'cancel', 'tomorrow', [
@@ -43,7 +43,7 @@ class CRM_Contract_CustomisationTest extends CRM_Contract_ContractTestBase {
     ]);
     $this->runContractEngine($contract['id'], '+2 days');
     $last_change = $this->getLastChangeActivity($contract['id']);
-    static::assertEquals('TEST-cancel', $last_change['subject'], 'The customisation hook failed.');
+    static::assertEquals('TEST-Contract_Cancelled', $last_change['subject'], 'The customisation hook failed.');
   }
 
   /**
@@ -55,7 +55,7 @@ class CRM_Contract_CustomisationTest extends CRM_Contract_ContractTestBase {
    * @see https://projekte.systopia.de/issues/18511#note-10
    */
   public static function renderSubjectTest1(RenderChangeSubjectEvent $event) {
-    $event->setRenderedSubject('TEST-' . $event->getActivityAction());
+    $event->setRenderedSubject('TEST-' . $event->getActivityTypeName());
   }
 
 }

--- a/tests/phpunit/CRM/Contract/UpgraderTest.php
+++ b/tests/phpunit/CRM/Contract/UpgraderTest.php
@@ -68,9 +68,8 @@ class CRM_Contract_UpgraderTest extends CRM_Contract_ContractTestBase {
   }
 
   private function createUnmigratedContractActivity(int $sourceRecordId): int {
-    $activityTypeIds = CRM_Contract_Change::getActivityTypeIds();
     $activity = Activity::create(FALSE)
-      ->addValue('activity_type_id', reset($activityTypeIds))
+      ->addValue('activity_type_id:name', CRM_Contract_Change_Sign::getActivityTypeName())
       ->addValue('source_record_id', $sourceRecordId)
       ->addValue('source_contact_id', $this->createContactWithRandomEmail()['id'])
       ->addValue('subject', 'Upgrader test activity')

--- a/tests/phpunit/Civi/Contract/Event/RenderChangeSubjectEventTest.php
+++ b/tests/phpunit/Civi/Contract/Event/RenderChangeSubjectEventTest.php
@@ -14,7 +14,7 @@ final class RenderChangeSubjectEventTest extends AbstractSetupHeadless {
 
   public function testGetMembershipIncreaseAmount_WithFloatValues_CalculatesDiff(): void {
     $event = new RenderChangeSubjectEvent(
-      'update',
+      new \CRM_Contract_Change_Update([]),
       ['membership_payment.membership_annual' => 77379.0],
       ['membership_payment.membership_annual' => 77500.0]
     );
@@ -24,7 +24,7 @@ final class RenderChangeSubjectEventTest extends AbstractSetupHeadless {
 
   public function testGetMembershipIncreaseAmount_WithFloatValues_CalculatesReduction(): void {
     $event = new RenderChangeSubjectEvent(
-      'update',
+      new \CRM_Contract_Change_Update([]),
       ['membership_payment.membership_annual' => 120.0],
       ['membership_payment.membership_annual' => 60.0]
     );
@@ -34,7 +34,7 @@ final class RenderChangeSubjectEventTest extends AbstractSetupHeadless {
 
   public function testGetMembershipIncreaseAmount_WithFormattedStrings_StripsThousandSeparator(): void {
     $event = new RenderChangeSubjectEvent(
-      'update',
+      new \CRM_Contract_Change_Update([]),
       ['membership_payment.membership_annual' => '1.200,00'],
       ['membership_payment.membership_annual' => '1.500,00']
     );
@@ -43,7 +43,7 @@ final class RenderChangeSubjectEventTest extends AbstractSetupHeadless {
   }
 
   public function testGetMembershipIncreaseAmount_WithoutContractData_ReturnsZero(): void {
-    $event = new RenderChangeSubjectEvent('update', [], []);
+    $event = new RenderChangeSubjectEvent(new \CRM_Contract_Change_Update([]), [], []);
 
     self::assertEqualsWithDelta(0.0, $event->getMembershipIncreaseAmount(), 0.001);
   }


### PR DESCRIPTION
This PR contains a refactoring of `\CRM_Contract_Change` and related classes. The various change types are now registered in `\Civi\Contract\ContractChange\ContractChangeTypeContainer`.

There are now two interfaces for change type classes: `\Civi\Contract\ContractChange\ContractChangeInterface` and `\Civi\Contract\ContractChange\SchedulableContractChangeInterface`. The latter one extends the first one and adds methods for change types that can be scheduled and executed later. Classes that implement only `ContractChangeInterface` are meant for informational purposes.

The class `\CRM_Contract_Change_Upgrade` is renamed `\CRM_Contract_Change_Update` to match the action/activity type name.

The implementation of `hook_civicrm_links()` has moved to `\Civi\Contract\EventSubscriber\CivicrmLinksSubscriber`.

It would make sense to move the change classes to the `\Civi\Contract\ContractChange` namespace, but that's not part of this PR, yet.

Maybe we could additionally extract `modifyMembershipActionLinks()` and could avoid hard-coding the available SearchDisplay links in `\Civi\Contract\SearchDisplayLinks::getActiveDisplayLinks()`. That would require that the contract change classes define a weight/priority and few other attributes (e.g. icon for SearchDisplay link).

systopia-reference: 34651